### PR TITLE
Control search point on latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Add the following step to your GitHub workflow:
       {"title": "Bugfixes 🛠", "label": "bug"}
     ]'
     warnings: true
+    published-at: true
 ```
 
 ### Configure the Action
@@ -40,6 +41,7 @@ Configure the action by customizing the following parameters based on your needs
 - **tag-name** (required): The name of the tag for which you want to generate release notes. This should be the same as the tag name used in the release workflow.
 - **chapters** (required): A JSON string defining chapters and corresponding labels for categorization. Each chapter, like "Breaking Changes", "New Features", and "Bugfixes", should have a title and a label matching your GitHub issues and PRs.
 - **warnings** (optional): Set to true to enable warnings in the release notes. These warnings identify issues without release notes, without user-defined labels, or without associated pull requests, and PRs without linked issues. Defaults to false if not specified.
+- **published-at** (optional): Set to true to enable the use of the `published-at` timestamp as the reference point for searching closed issues and PRs, instead of the `created-at` date of the latest release.
 
 ## Setup
 ### Build the Action:

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
     description: 'Print warning chapters if true.'
     required: false
     default: 'false'
+  published-at:
+    description: 'Use `published-at` timestamp instead of `created-at` as the reference point.'
+    required: false
+    default: 'false'
 
 branding:
   icon: 'book'

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -268,13 +268,19 @@ function parseChaptersJson(chaptersJson) {
  * @param {string} repoOwner - The owner of the repository.
  * @param {string} repoName - The name of the repository.
  * @param {Object} latestRelease - The latest release object.
+ * @param {boolean} usePublishedAt - Flag to use created-at or published-at time point.
  * @returns {Promise<Array>} An array of closed issues since the latest release.
  */
-async function fetchClosedIssues(octokit, repoOwner, repoName, latestRelease) {
+async function fetchClosedIssues(octokit, repoOwner, repoName, latestRelease, usePublishedAt) {
     let since;
-    if (latestRelease && latestRelease.created_at) {
-        since = new Date(latestRelease.created_at)
-        console.log(`Fetching closed issues since ${since.toISOString()}`);
+    if (latestRelease) {
+        if (usePublishedAt) {
+            since = new Date(latestRelease.published_at)
+            console.log(`Fetching closed issues since ${since.toISOString()} - published-at.`);
+        } else {
+            since = new Date(latestRelease.created_at)
+            console.log(`Fetching closed issues since ${since.toISOString()} - created-at.`);
+        }
     } else {
         const firstClosedIssue = await octokit.rest.issues.listForRepo({
             owner: repoOwner,
@@ -310,22 +316,30 @@ async function fetchClosedIssues(octokit, repoOwner, repoName, latestRelease) {
  * @param {string} repoOwner - The owner of the repository.
  * @param {string} repoName - The name of the repository.
  * @param {Object} latestRelease - The latest release object.
+ * @param {boolean} usePublishedAt - Flag to use created-at or published-at time point.
  * @returns {Promise<Array>} An array of closed pull requests since the latest release.
  */
-async function fetchPullRequests(octokit, repoOwner, repoName, latestRelease) {
+async function fetchPullRequests(octokit, repoOwner, repoName, latestRelease, usePublishedAt) {
     console.log(`Fetching closed pull requests for ${repoOwner}/${repoName}`);
 
     if (latestRelease) {
-        console.log(`Since latest release date: ${latestRelease.created_at}`);
+        let since;
+        if (usePublishedAt) {
+            console.log(`Since latest release date: ${latestRelease.published_at} - published-at.`);
+            since = new Date(latestRelease.published_at);
+        } else {
+            console.log(`Since latest release date: ${latestRelease.created_at} - created-at.`);
+            since = new Date(latestRelease.created_at);
+        }
+
         return await octokit.rest.pulls.list({
             owner: repoOwner,
             repo: repoName,
             state: 'closed',
             sort: 'updated',
             direction: 'desc',
-            since: new Date(latestRelease.created_at)
+            since: since
         });
-
     } else {
         console.log("No latest release found. Fetching all closed pull requests.");
         return await octokit.rest.pulls.list({
@@ -345,6 +359,7 @@ async function run() {
     const chaptersJson = core.getInput('chapters');
     const warnings = core.getInput('warnings').toLowerCase() === 'true';
     const githubToken = process.env.GITHUB_TOKEN;
+    const usePublishedAt = core.getInput('published-at').toLowerCase() === 'true';
 
     // Validate environment variables and arguments
     if (!githubToken || !repoOwner || !repoName) {
@@ -358,7 +373,7 @@ async function run() {
         const latestRelease = await fetchLatestRelease(octokit, repoOwner, repoName);
 
         // Fetch closed issues since the latest release
-        const closedIssuesOnlyIssues = await fetchClosedIssues(octokit, repoOwner, repoName, latestRelease);
+        const closedIssuesOnlyIssues = await fetchClosedIssues(octokit, repoOwner, repoName, latestRelease, usePublishedAt);
         console.log(`Found ${closedIssuesOnlyIssues.length} closed issues (only Issues) since last release`);
 
         // Initialize variables for each chapter
@@ -405,7 +420,7 @@ async function run() {
         // Check PRs for linked issues
         if (warnings) {
             // Fetch pull requests since the latest release
-            const prsSinceLastRelease = await fetchPullRequests(octokit, repoOwner, repoName, latestRelease);
+            const prsSinceLastRelease = await fetchPullRequests(octokit, repoOwner, repoName, latestRelease, usePublishedAt);
             console.log(`Found ${prsSinceLastRelease.data.length} closed PRs since last release`);
             const sortedPRs = prsSinceLastRelease.data.sort((a, b) => new Date(a.created_at) - new Date(b.created_at));
 


### PR DESCRIPTION
Implemented new logic. User can newly decide if action will be searching from latest release created-at or published-at point.

Closes #13 