### PR TITLE
# 33 - Make more robust Release notes comment logic

### DIFF
--- a/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
+++ b/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
@@ -17,6 +17,7 @@
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Closed Issues without Pull Request ⚠️

--- a/__tests__/data/rls_notes_fully_populated_first_release.md
+++ b/__tests__/data/rls_notes_fully_populated_first_release.md
@@ -19,6 +19,7 @@
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Closed Issues without Pull Request ⚠️

--- a/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
@@ -19,6 +19,7 @@
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_in_default.md
+++ b/__tests__/data/rls_notes_fully_populated_in_default.md
@@ -19,6 +19,7 @@
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Closed Issues without Pull Request ⚠️

--- a/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
@@ -21,6 +21,7 @@
   - note about change in Issue 2
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Closed Issues without Release Notes ⚠️

--- a/__tests__/mocks/octokit.mocks.js
+++ b/__tests__/mocks/octokit.mocks.js
@@ -421,6 +421,13 @@ const mockFullPerfectData = () => ({
                                 created_at: '2023-01-02T11:00:00Z',
                                 updated_at: '2023-01-02T11:00:00Z'
                             },
+                            {
+                                id: 103,
+                                user: {login: 'user2'},
+                                body: 'Release notes:\nnote about change in Issue 1 (no bullet point at start of line)',
+                                created_at: '2023-01-02T12:00:00Z',
+                                updated_at: '2023-01-02T12:01:00Z'
+                            },
                         ]
                     });
                 } else if (issue_number === 2) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29177,7 +29177,20 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
         if (comment.body.toLowerCase().startsWith('release notes')) {
             const noteContent = comment.body.replace(/^release notes:?.*(\r\n|\n|\r)?/i, '').trim();
             console.log(`Found release notes in comments for issue #${issueNumber}`);
-            releaseNotes.push(noteContent.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  '));
+
+            // Process each line of the noteContent
+            const processedContent = noteContent.split(/\r?\n/).map(line => {
+                // Check if the line starts with "  -"
+                if (!line.startsWith("-")) {
+                    // Remove leading whitespace and prepend "  - "
+                    return "  - " + line.trim();
+                } else {
+                    // Remove leading whitespace
+                    return line.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  ');
+                }
+            }).join('\n');
+
+            releaseNotes.push(processedContent);
         }
     }
 

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -155,7 +155,20 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
         if (comment.body.toLowerCase().startsWith('release notes')) {
             const noteContent = comment.body.replace(/^release notes:?.*(\r\n|\n|\r)?/i, '').trim();
             console.log(`Found release notes in comments for issue #${issueNumber}`);
-            releaseNotes.push(noteContent.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  '));
+
+            // Process each line of the noteContent
+            const processedContent = noteContent.split(/\r?\n/).map(line => {
+                // Check if the line starts with "  -"
+                if (!line.startsWith("-")) {
+                    // Remove leading whitespace and prepend "  - "
+                    return "  - " + line.trim();
+                } else {
+                    // Remove leading whitespace
+                    return line.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  ');
+                }
+            }).join('\n');
+
+            releaseNotes.push(processedContent);
         }
     }
 


### PR DESCRIPTION
- Improved logic to check release notes lines for presence of '-'. If not present add it with required indent.

Closes #33 