### PR TITLE
Feature/26 introduce idea of pr without issue as part for user defined chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Add the following step to your GitHub workflow (in example are used non-default 
     published-at: true
     skip-release-notes-label: 'ignore-in-release'     # changing default value of label
     print-empty-chapters: false
+    chapters-to-pr-without-issue: true
 ```
 
 ### Configure the Action
@@ -46,6 +47,7 @@ Configure the action by customizing the following parameters based on your needs
 - **published-at** (optional): Set to true to enable the use of the `published-at` timestamp as the reference point for searching closed issues and PRs, instead of the `created-at` date of the latest release.
 - **skip-release-notes** (optional): Set to a label name to skip issues and PRs with this label from release notes process generation. Defaults to `skip-release-notes` if not specified.
 - **print-empty-chapters** (optional): Set to true to print chapters with no issues or PRs. Defaults to false if not specified.
+- **chapters-to-pr-without-issue** (optional): Set false to avoid application of custom chapters for PRs without linked issues. Defaults to true if not specified.
 
 ## Setup
 ### Build the Action:

--- a/__tests__/data/rls_notes_empty_with_all_chapters.md
+++ b/__tests__/data/rls_notes_empty_with_all_chapters.md
@@ -16,13 +16,13 @@ All closed issues contain at least one of user defined labels.
 ### Closed Issues without Release Notes ⚠️
 All closed issues have release notes.
 
-### Merged PRs without Linked Issue ⚠️
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 All merged PRs are linked to issues.
 
 ### Merged PRs Linked to Open Issue ⚠️
 All merged PRs are linked to Closed issues.
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 All closed PRs are linked to issues.
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_empty_with_no_custom_chapters.md
+++ b/__tests__/data/rls_notes_empty_with_no_custom_chapters.md
@@ -7,13 +7,13 @@ All closed issues contain at least one of user defined labels.
 ### Closed Issues without Release Notes ⚠️
 All closed issues have release notes.
 
-### Merged PRs without Linked Issue ⚠️
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 All merged PRs are linked to issues.
 
 ### Merged PRs Linked to Open Issue ⚠️
 All merged PRs are linked to Closed issues.
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 All closed PRs are linked to issues.
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
+++ b/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
@@ -39,16 +39,16 @@
 
 
 ### Merged PRs without Linked Issue ⚠️
-#1004 _Pull Request 4 - no linked issue - merged_
-#1006 _Pull Request 6 - skip label_
+- #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
+- #1006 _Pull Request 6 - skip label_ implemented by @janeDoe
 
 
 ### Merged PRs Linked to Open Issue ⚠️
-#1003 _Pull Request 3 - linked to open issue_
+- #1003 _Pull Request 3 - linked to open issue_
 
 
 ### Closed PRs without Linked Issue ⚠️
-#1002 _Pull Request 2 - no linked issue - closed_
+- #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
+++ b/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
@@ -12,6 +12,9 @@
   - note about change in Issue 4
 - #2 _Issue title 2_ implemented by @johnDoe in [#2](link-to-pr-2)
   - note about change in Issue 2
+- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+  - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Bugfixes 🛠
@@ -38,7 +41,7 @@
 - #3 _Issue title 3 - no release note comment|typo label_ implemented by @janeDoe in [#3](link-to-pr-3)
 
 
-### Merged PRs without Linked Issue ⚠️
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 - #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 - #1006 _Pull Request 6 - skip label_ implemented by @janeDoe
 
@@ -47,7 +50,7 @@
 - #1003 _Pull Request 3 - linked to open issue_
 
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 - #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 

--- a/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
+++ b/__tests__/data/rls_notes_fully_populated_custom_skip_label.md
@@ -18,7 +18,7 @@
 
 
 ### Bugfixes 🛠
-- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+- **<span style="color: red;">[Duplicate]<span>** #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
 

--- a/__tests__/data/rls_notes_fully_populated_first_release.md
+++ b/__tests__/data/rls_notes_fully_populated_first_release.md
@@ -38,16 +38,18 @@
 
 
 ### Merged PRs without Linked Issue ⚠️
-#1001 _Pull Request 1_
-#1004 _Pull Request 4 - no linked issue - merged_
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
+- #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 
 
 ### Merged PRs Linked to Open Issue ⚠️
-#1003 _Pull Request 3 - linked to open issue_
+- #1003 _Pull Request 3 - linked to open issue_
 
 
 ### Closed PRs without Linked Issue ⚠️
-#1002 _Pull Request 2 - no linked issue - closed_
+- #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_first_release.md
+++ b/__tests__/data/rls_notes_fully_populated_first_release.md
@@ -23,10 +23,10 @@
 
 
 ### Bugfixes 🛠
-- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+- **<span style="color: red;">[Duplicate]<span>** #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
-- #1001 _Pull Request 1_ implemented by @janeDoe
+- **<span style="color: red;">[Duplicate]<span>** #1001 _Pull Request 1_ implemented by @janeDoe
   - This is second PR comment ad RLS note
   - This is third PR comment ad RLS note
 

--- a/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
@@ -14,6 +14,9 @@
   - note about change in Issue 4
 - #2 _Issue title 2_ implemented by @johnDoe in [#2](link-to-pr-2)
   - note about change in Issue 2
+- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+  - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
 
 
 ### Bugfixes 🛠

--- a/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_hide_warning_chapters.md
@@ -20,7 +20,7 @@
 
 
 ### Bugfixes 🛠
-- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+- **<span style="color: red;">[Duplicate]<span>** #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
 

--- a/__tests__/data/rls_notes_fully_populated_in_default.md
+++ b/__tests__/data/rls_notes_fully_populated_in_default.md
@@ -38,16 +38,18 @@
 
 
 ### Merged PRs without Linked Issue ⚠️
-#1001 _Pull Request 1_
-#1004 _Pull Request 4 - no linked issue - merged_
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
+- #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 
 
 ### Merged PRs Linked to Open Issue ⚠️
-#1003 _Pull Request 3 - linked to open issue_
+- #1003 _Pull Request 3 - linked to open issue_
 
 
 ### Closed PRs without Linked Issue ⚠️
-#1002 _Pull Request 2 - no linked issue - closed_
+- #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_in_default.md
+++ b/__tests__/data/rls_notes_fully_populated_in_default.md
@@ -14,12 +14,21 @@
   - note about change in Issue 4
 - #2 _Issue title 2_ implemented by @johnDoe in [#2](link-to-pr-2)
   - note about change in Issue 2
+- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+  - note about change in Issue 1
+  - note about change in Issue 1 (no bullet point at start of line)
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
 
 
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
 
 
 ### Closed Issues without Pull Request ⚠️
@@ -37,10 +46,7 @@
 - #3 _Issue title 3 - no release note comment|typo label_ implemented by @janeDoe in [#3](link-to-pr-3)
 
 
-### Merged PRs without Linked Issue ⚠️
-- #1001 _Pull Request 1_ implemented by @janeDoe
-  - This is second PR comment ad RLS note
-  - This is third PR comment ad RLS note
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 - #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 
 
@@ -48,7 +54,7 @@
 - #1003 _Pull Request 3 - linked to open issue_
 
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 - #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 

--- a/__tests__/data/rls_notes_fully_populated_in_default.md
+++ b/__tests__/data/rls_notes_fully_populated_in_default.md
@@ -23,10 +23,10 @@
 
 
 ### Bugfixes 🛠
-- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+- **<span style="color: red;">[Duplicate]<span>** #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
-- #1001 _Pull Request 1_ implemented by @janeDoe
+- **<span style="color: red;">[Duplicate]<span>** #1001 _Pull Request 1_ implemented by @janeDoe
   - This is second PR comment ad RLS note
   - This is third PR comment ad RLS note
 

--- a/__tests__/data/rls_notes_fully_populated_no_PRs_in_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_no_PRs_in_chapters.md
@@ -20,7 +20,7 @@
 
 
 ### Bugfixes 🛠
-- #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
+- **<span style="color: red;">[Duplicate]<span>** #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
 

--- a/__tests__/data/rls_notes_fully_populated_no_PRs_in_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_no_PRs_in_chapters.md
@@ -17,18 +17,12 @@
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
-- #1001 _Pull Request 1_ implemented by @janeDoe
-  - This is second PR comment ad RLS note
-  - This is third PR comment ad RLS note
 
 
 ### Bugfixes 🛠
 - #1 _Issue title 1_ implemented by @janeDoe in [#1](link-to-pr-1)
   - note about change in Issue 1
   - note about change in Issue 1 (no bullet point at start of line)
-- #1001 _Pull Request 1_ implemented by @janeDoe
-  - This is second PR comment ad RLS note
-  - This is third PR comment ad RLS note
 
 
 ### Closed Issues without Pull Request ⚠️
@@ -47,6 +41,9 @@
 
 
 ### Merged PRs without Linked Issue and Custom Labels ⚠️
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
 - #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 
 
@@ -59,4 +56,4 @@
 
 
 #### Full Changelog
-https://github.com/owner/repo-no-rls/commits/v0.1.1
+https://github.com/owner/repo/compare/v0.1.0...v0.1.1

--- a/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
@@ -28,7 +28,7 @@
 - #3 _Issue title 3 - no release note comment|typo label_ implemented by @janeDoe in [#3](link-to-pr-3)
 
 
-### Merged PRs without Linked Issue ⚠️
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 - #1001 _Pull Request 1_ implemented by @janeDoe
   - This is second PR comment ad RLS note
   - This is third PR comment ad RLS note
@@ -39,7 +39,7 @@
 - #1003 _Pull Request 3 - linked to open issue_
 
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 - #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 

--- a/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
+++ b/__tests__/data/rls_notes_fully_populated_no_custom_chapters.md
@@ -29,16 +29,18 @@
 
 
 ### Merged PRs without Linked Issue ⚠️
-#1001 _Pull Request 1_
-#1004 _Pull Request 4 - no linked issue - merged_
+- #1001 _Pull Request 1_ implemented by @janeDoe
+  - This is second PR comment ad RLS note
+  - This is third PR comment ad RLS note
+- #1004 _Pull Request 4 - no linked issue - merged_ implemented by @janeDoe
 
 
 ### Merged PRs Linked to Open Issue ⚠️
-#1003 _Pull Request 3 - linked to open issue_
+- #1003 _Pull Request 3 - linked to open issue_
 
 
 ### Closed PRs without Linked Issue ⚠️
-#1002 _Pull Request 2 - no linked issue - closed_
+- #1002 _Pull Request 2 - no linked issue - closed_ implemented by @janeDoe
 
 
 #### Full Changelog

--- a/__tests__/data/rls_notes_fully_populated_second_release.md
+++ b/__tests__/data/rls_notes_fully_populated_second_release.md
@@ -16,13 +16,13 @@ All closed issues contain at least one of user defined labels.
 ### Closed Issues without Release Notes ⚠️
 All closed issues have release notes.
 
-### Merged PRs without Linked Issue ⚠️
+### Merged PRs without Linked Issue and Custom Labels ⚠️
 All merged PRs are linked to issues.
 
 ### Merged PRs Linked to Open Issue ⚠️
 All merged PRs are linked to Closed issues.
 
-### Closed PRs without Linked Issue ⚠️
+### Closed PRs without Linked Issue and Custom Labels ⚠️
 All closed PRs are linked to issues.
 
 #### Full Changelog

--- a/__tests__/generate-release-notes.test.js
+++ b/__tests__/generate-release-notes.test.js
@@ -247,6 +247,27 @@ describe('run', () => {
         expect(firstCallArgs[1]).toBe(expectedOutput);
     });
 
+    it('should run successfully with valid inputs - no PRs in chapter', async () => {
+        console.log('Test started: should run successfully with valid inputs - no PRs in chapter');
+
+        core.getInput.mockImplementation((name) => {
+            return coreMocks.fullAndNoChaptersForPRsInputs(name);
+        });
+        Octokit.mockImplementation(octokitMocks.mockFullPerfectData);
+
+        await run();
+
+        expect(core.setFailed).not.toHaveBeenCalled();
+
+        // Get the arguments of the first call to setOutput
+        const firstCallArgs = core.setOutput.mock.calls[0];
+        expect(firstCallArgs[0]).toBe('releaseNotes');
+
+        const filePath = path.join(__dirname, 'data', 'rls_notes_fully_populated_no_PRs_in_chapters.md');
+        let expectedOutput = fs.readFileSync(filePath, 'utf8');
+        expect(firstCallArgs[1]).toBe(expectedOutput);
+    });
+
     /*
     Happy path tests - no option related
     */

--- a/__tests__/mocks/core.mocks.js
+++ b/__tests__/mocks/core.mocks.js
@@ -17,6 +17,8 @@ const fullDefaultInputs = (name) => {
             return null;
         case 'print-empty-chapters':
             return 'true';
+        case 'chapters-to-pr-without-issue':
+            return 'true';
         default:
             return null;
     }
@@ -41,6 +43,8 @@ const fullAndHideEmptyChaptersInputs = (name) => {
             return null;
         case 'print-empty-chapters':
             return 'false';
+        case 'chapters-to-pr-without-issue':
+            return 'true';
         default:
             return null;
     }
@@ -64,6 +68,8 @@ const fullAndCustomSkipLabel = (name) => {
         case 'skip-release-notes-label':
             return 'user-custom-label';
         case 'print-empty-chapters':
+            return 'true';
+        case 'chapters-to-pr-without-issue':
             return 'true';
         default:
             return null;
@@ -89,6 +95,8 @@ const fullAndHideWarningChaptersInputs = (name) => {
             return null;
         case 'print-empty-chapters':
             return 'true';
+        case 'chapters-to-pr-without-issue':
+            return 'true';
         default:
             return null;
     }
@@ -106,6 +114,34 @@ const fullDefaultInputsNoCustomChapters = (name) => {
             return null;
         case 'print-empty-chapters':
             return 'true';
+        case 'chapters-to-pr-without-issue':
+            return 'true';
+        default:
+            return null;
+    }
+};
+
+const fullAndNoChaptersForPRsInputs = (name) => {
+    switch (name) {
+        case 'tag-name':
+            return 'v0.1.1';
+        case 'chapters':
+            return JSON.stringify([
+                {"title": "Breaking Changes 💥", "label": "breaking-change"},
+                {"title": "New Features 🎉", "label": "enhancement"},
+                {"title": "New Features 🎉", "label": "feature"},
+                {"title": "Bugfixes 🛠", "label": "bug"}
+            ]);
+        case 'warnings':
+            return 'true';
+        case 'published-at':
+            return 'false';
+        case 'skip-release-notes-label':
+            return null;
+        case 'print-empty-chapters':
+            return 'true';
+        case 'chapters-to-pr-without-issue':
+            return 'false';
         default:
             return null;
     }
@@ -118,4 +154,5 @@ module.exports = {
     fullAndHideWarningChaptersInputs,
     fullDefaultInputsNoCustomChapters,
     fullAndCustomSkipLabel,
+    fullAndNoChaptersForPRsInputs,
 };

--- a/__tests__/mocks/octokit.mocks.js
+++ b/__tests__/mocks/octokit.mocks.js
@@ -26,6 +26,9 @@ const mockEmptyData = () => ({
             listCommits: jest.fn().mockResolvedValue({
                 data: [],
             }),
+            listReviewComments: jest.fn().mockResolvedValue({
+                data: [],
+            }),
             get: jest.fn().mockResolvedValue({
                 data: [],
             }),
@@ -597,6 +600,11 @@ const mockFullPerfectData = () => ({
                             labels: [{ name: 'user-custom-label' }],
                             created_at: '2023-12-12T15:56:30.000Z',
                             merged_at: '2023-12-12T15:58:30.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                         {
                             number: 1002,
@@ -605,6 +613,11 @@ const mockFullPerfectData = () => ({
                             labels: [],
                             created_at: '2023-12-12T15:57:30.000Z',
                             closed_at: '2023-12-12T15:58:30.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                         {
                             number: 1003,
@@ -613,6 +626,11 @@ const mockFullPerfectData = () => ({
                             labels: [],
                             created_at: '2023-12-12T15:58:30.000Z',
                             merged_at: '2023-12-12T15:59:30.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                         {
                             number: 1004,
@@ -621,6 +639,11 @@ const mockFullPerfectData = () => ({
                             labels: [],
                             created_at: '2023-12-12T15:59:30.000Z',
                             merged_at: '2023-12-12T16:59:30.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                         {
                             number: 1005,
@@ -628,6 +651,11 @@ const mockFullPerfectData = () => ({
                             state: 'open',
                             labels: [],
                             created_at: '2023-12-12T15:59:35.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                         {
                             number: 1006,
@@ -636,6 +664,11 @@ const mockFullPerfectData = () => ({
                             labels: [{ name: 'skip-release-notes' }],
                             created_at: '2023-12-12T15:59:37.000Z',
                             merged_at: '2023-12-12T17:59:37.000Z',
+                            assignees: [
+                                {
+                                    login: "janeDoe",
+                                },
+                            ],
                         },
                     ],
                 });
@@ -676,6 +709,27 @@ const mockFullPerfectData = () => ({
                                 url: 'https://api.github.com/repos/owner/repo/commits/abc124'
                             },
                         ]
+                    });
+                } else {
+                    return Promise.resolve({
+                        data: [],
+                    });
+                }
+            }),
+            listReviewComments: jest.fn(({owner, repo, pull_number}) => {
+                if (pull_number === 1001) {
+                    return Promise.resolve({
+                        data: [
+                            {
+                                body: 'This is first PR comment.',
+                            },
+                            {
+                                body: 'Release notes\nThis is second PR comment ad RLS note',
+                            },
+                            {
+                                body: 'Release notes\nThis is third PR comment ad RLS note',
+                            },
+                        ],
                     });
                 } else {
                     return Promise.resolve({
@@ -876,6 +930,11 @@ const mockPerfectDataWithoutIssues = () => ({
                         data: [],
                     });
                 }
+            }),
+            listReviewComments: jest.fn(({owner, repo, pull_number}) => {
+                return Promise.resolve({
+                    data: [],
+                });
             }),
             get: jest.fn(({owner, repo, pull_number}) => {
                 if (pull_number === 1003) {

--- a/__tests__/mocks/octokit.mocks.js
+++ b/__tests__/mocks/octokit.mocks.js
@@ -71,7 +71,7 @@ const mockFullPerfectData = () => ({
                         number: 1,
                         title: 'Issue title 1',
                         state: 'closed',
-                        labels: [{ name: 'bug' }],
+                        labels: [{ name: 'bug' }, { name: 'feature'}],
                         assignees: [
                             {
                                 login: "janeDoe",
@@ -597,7 +597,17 @@ const mockFullPerfectData = () => ({
                             number: 1001,
                             title: 'Pull Request 1',
                             state: 'merged',
-                            labels: [{ name: 'user-custom-label' }],
+                            labels: [
+                                {
+                                    name: 'user-custom-label'
+                                },
+                                {
+                                    name: 'bug'
+                                },
+                                {
+                                    name: 'feature'
+                                },
+                            ],
                             created_at: '2023-12-12T15:56:30.000Z',
                             merged_at: '2023-12-12T15:58:30.000Z',
                             assignees: [

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'Print chapters even if they are empty.'
     required: false
     default: 'true'
+  chapters-to-pr-without-issue:
+    description: 'Apply custom chapters for PRs without linked issues.'
+    required: false
+    default: 'true'
 
 branding:
   icon: 'book'

--- a/dist/index.js
+++ b/dist/index.js
@@ -29509,7 +29509,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN;
     const tagName = core.getInput('tag-name');
     const githubRepository = process.env.GITHUB_REPOSITORY;
-    const duplicate = "- **<span style=\"color: red;\">[Duplicate]<span>** #";
+    const duplicate = "- _**<span style=\"color: red;\">[Duplicate]<span>**_ #";
 
     // Validate GitHub token
     if (!githubToken) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29509,7 +29509,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN;
     const tagName = core.getInput('tag-name');
     const githubRepository = process.env.GITHUB_REPOSITORY;
-    const duplicate = "- _**<span style=\"color: red;\">[Duplicate]<span>**_ #";
+    const duplicate = "- _**[Duplicate]**_ #";
 
     // Validate GitHub token
     if (!githubToken) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -29509,6 +29509,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN;
     const tagName = core.getInput('tag-name');
     const githubRepository = process.env.GITHUB_REPOSITORY;
+    const duplicate = "- **<span style=\"color: red;\">[Duplicate]<span>** #";
 
     // Validate GitHub token
     if (!githubToken) {
@@ -29583,8 +29584,12 @@ async function run() {
             let foundUserLabels = false;
             titlesToLabelsMap.forEach((labels, title) => {
                 if (labels.some(label => issue.labels.map(l => l.name).includes(label))) {
-                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                    foundUserLabels = true;
+                    if (foundUserLabels) {
+                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                    } else {
+                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                        foundUserLabels = true;
+                    }
                 }
             });
 
@@ -29614,8 +29619,12 @@ async function run() {
                         if (chaptersToPRWithoutIssue) {
                             titlesToLabelsMap.forEach((labels, title) => {
                                 if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
-                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                                    foundUserLabels = true;
+                                    if (foundUserLabels) {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                                    } else {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                        foundUserLabels = true;
+                                    }
                                 }
                             });
                         }
@@ -29648,12 +29657,16 @@ async function run() {
                         if (chaptersToPRWithoutIssue) {
                             titlesToLabelsMap.forEach((labels, title) => {
                                 if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
-                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                                    foundUserLabels = true;
+                                    if (foundUserLabels) {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                                    } else {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                        foundUserLabels = true;
+                                    }
                                 }
                             });
                         }
-                        
+
                         if (!foundUserLabels) {
                             closedPRsWithoutLinkToIssue += releaseNotes;
                         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -29067,39 +29067,17 @@ async function getRelatedPRsForIssue(octokit, issueNumber, repoOwner, repoName) 
 }
 
 /**
- * Fetches contributors for an issue.
- * @param {Array} issueAssignees - List of assignees for the issue.
+ * Fetches contributors for an issue or pull request.
+ * @param {Array} assignees - List of assignees for the issue or pull request.
  * @param {Array} commitAuthors - List of authors of commits.
  * @returns {Set<string>} A set of contributors' usernames.
  */
-async function getIssueContributors(issueAssignees, commitAuthors) {
-    // Map the issueAssignees to the required format
-    const assignees = issueAssignees.map(assignee => '@' + assignee.login);
+async function getContributors(assignees, commitAuthors) {
+    // Map the assignees to the required format
+    const loginAssignees = assignees.map(assignee => '@' + assignee.login);
 
-    // Combine the assignees and commit authors
-    const combined = [...assignees, ...commitAuthors];
-
-    // Check if the combined array is empty
-    if (combined && combined.length === 0) {
-        return new Set(["\"Missing Assignee or Contributor\""]);
-    }
-
-    // If not empty, return the Set of combined values
-    return new Set(combined);
-}
-
-/**
- * Fetches contributors for a pull request.
- * @param {Array} prAssignees - List of assignees for the pull requests.
- * @param {Array} commitAuthors - List of authors of commits.
- * @returns {Set<string>} A set of contributors' usernames.
- */
-async function getPRContributors(prAssignees, commitAuthors) {
-    // Map the prAssignees to the required format
-    const assignees = prAssignees.map(assignee => '@' + assignee.login);
-
-    // Combine the assignees and commit authors
-    const combined = [...assignees, ...commitAuthors];
+    // Combine the loginAssignees and commit authors
+    const combined = [...loginAssignees, ...commitAuthors];
 
     // Check if the combined array is empty
     if (combined && combined.length === 0) {
@@ -29226,7 +29204,7 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
     console.log(`Fetching release notes from comments for issue #${issueNumber}`);
     const comments = await getIssueComments(octokit, issueNumber, repoOwner, repoName);
     let commitAuthors = await getPRCommitAuthors(octokit, repoOwner, repoName, relatedPRs);
-    let contributors = await getIssueContributors(issueAssignees, commitAuthors);
+    let contributors = await getContributors(issueAssignees, commitAuthors);
     let releaseNotes = await extractReleaseNotesFromComments(comments.data);
     const contributorsList = Array.from(contributors).join(', ');
 
@@ -29262,7 +29240,7 @@ async function getReleaseNotesFromPRComments(octokit, prNumber, prTitle, prAssig
     console.log(`Fetching release notes from comments for pull request #${prNumber}`);
     const comments = await getPRComments(octokit, prNumber, repoOwner, repoName);
     let commitAuthors = await getPRCommitAuthorsByPRNumber(octokit, repoOwner, repoName, prNumber);
-    let contributors = await getPRContributors(prAssignees, commitAuthors);
+    let contributors = await getContributors(prAssignees, commitAuthors);
     let releaseNotes = await extractReleaseNotesFromComments(comments.data);
     const contributorsList = Array.from(contributors).join(', ');
 
@@ -29384,10 +29362,20 @@ async function isPrLinkedToOpenIssue(octokit, prNumber, repoOwner, repoName) {
  * @returns {Map<string, string[]>} A map where each key is a chapter title and the value is an array of corresponding labels.
  */
 function parseChaptersJson(chaptersJson) {
+    const titlesToLabelsMap = new Map();
+
     try {
         const chaptersArray = JSON.parse(chaptersJson);
+        if (!Array.isArray(chaptersArray)) {
+            throw new Error("Parsed data is not an array.");
+        }
+
         const titlesToLabelsMap = new Map();
         chaptersArray.forEach(chapter => {
+            if (typeof chapter.title !== 'string' || typeof chapter.label !== 'string') {
+                throw new Error("Invalid chapter format. Each chapter must have a string title and a string label.");
+            }
+
             if (titlesToLabelsMap.has(chapter.title)) {
                 titlesToLabelsMap.get(chapter.title).push(chapter.label);
             } else {
@@ -29397,6 +29385,7 @@ function parseChaptersJson(chaptersJson) {
         return titlesToLabelsMap;
     } catch (error) {
         core.setFailed(`Error parsing chapters JSON: ${error.message}`)
+        return new Map();
     }
 }
 

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -205,30 +205,9 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
     const comments = await getIssueComments(octokit, issueNumber, repoOwner, repoName);
     let commitAuthors = await getPRCommitAuthors(octokit, repoOwner, repoName, relatedPRs);
     let contributors = await getIssueContributors(issueAssignees, commitAuthors);
-
-    let releaseNotes = [];
-    for (const comment of comments.data) {
-        if (comment.body.toLowerCase().startsWith('release notes')) {
-            const noteContent = comment.body.replace(/^release notes:?.*(\r\n|\n|\r)?/i, '').trim();
-            console.log(`Found release notes in comments for issue #${issueNumber}`);
-
-            // Process each line of the noteContent
-            const processedContent = noteContent.split(/\r?\n/).map(line => {
-                // Check if the line starts with "  -"
-                if (!line.startsWith("-")) {
-                    // Remove leading whitespace and prepend "  - "
-                    return "  - " + line.trim();
-                } else {
-                    // Remove leading whitespace
-                    return line.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  ');
-                }
-            }).join('\n');
-
-            releaseNotes.push(processedContent);
-        }
-    }
-
+    let releaseNotes = await extractReleaseNotesFromComments(comments.data);
     const contributorsList = Array.from(contributors).join(', ');
+
     if (releaseNotes.length === 0) {
         console.log(`No specific release notes found in comments for issue #${issueNumber}`);
         if (relatedPRs.length === 0) {
@@ -237,6 +216,7 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
             return `- x#${issueNumber} _${issueTitle}_ implemented by ${contributorsList} in ${relatedPRLinksString}\n`;
         }
     } else {
+        console.log(`Found release notes in comments for issue #${issueNumber}`);
         const notes = releaseNotes.join('\n');
         if (relatedPRs.length === 0) {
             return `- #${issueNumber} _${issueTitle}_ implemented by ${contributorsList}\n${notes}\n`;
@@ -261,13 +241,30 @@ async function getReleaseNotesFromPRComments(octokit, prNumber, prTitle, prAssig
     const comments = await getPRComments(octokit, prNumber, repoOwner, repoName);
     let commitAuthors = await getPRCommitAuthorsByPRNumber(octokit, repoOwner, repoName, prNumber);
     let contributors = await getPRContributors(prAssignees, commitAuthors);
+    let releaseNotes = await extractReleaseNotesFromComments(comments.data);
+    const contributorsList = Array.from(contributors).join(', ');
 
-    // TODO candidate for refactoring - duplicite
+    if (releaseNotes.length === 0) {
+        console.log(`No specific release notes found in comments for pull request #${prNumber}`);
+        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n`;
+    } else {
+        console.log(`Found release notes in comments for pull request #${prNumber}`);
+        const notes = releaseNotes.join('\n');
+        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n${notes}\n`;
+    }
+}
+
+/**
+ * Extract release notes from comments.
+ * @param comments - The comments to extract release notes from.
+ * @returns {Promise<*[]>} An array of release notes.
+ */
+async function extractReleaseNotesFromComments(comments) {
     let releaseNotes = [];
-    for (const comment of comments.data) {
+
+    for (const comment of comments) {
         if (comment.body.toLowerCase().startsWith('release notes')) {
             const noteContent = comment.body.replace(/^release notes:?.*(\r\n|\n|\r)?/i, '').trim();
-            console.log(`Found release notes in comments for pull request #${prNumber}`);
 
             // Process each line of the noteContent
             const processedContent = noteContent.split(/\r?\n/).map(line => {
@@ -285,15 +282,7 @@ async function getReleaseNotesFromPRComments(octokit, prNumber, prTitle, prAssig
         }
     }
 
-    const contributorsList = Array.from(contributors).join(', ');
-    if (releaseNotes.length === 0) {
-        console.log(`No specific release notes found in comments for pull request #${prNumber}`);
-        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n`;
-    } else {
-        console.log(`Release notes: ${releaseNotes}`);
-        const notes = releaseNotes.join('\n');
-        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n${notes}\n`;
-    }
+    return releaseNotes;
 }
 
 /**

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -541,7 +541,7 @@ async function run() {
         let closedIssuesWithoutReleaseNotes = '', closedIssuesWithoutUserLabels = '', closedIssuesWithoutPR = '', mergedPRsWithoutLinkToIssue = '';
         let mergedPRsLinkedToOpenIssue = '', closedPRsWithoutLinkToIssue = '';
 
-        // Categorize issues and PRs
+        // Categorize issues into chapters
         for (const issue of closedIssuesOnlyIssues) {
             let relatedPRs = await getRelatedPRsForIssue(octokit, issue.number, repoOwner, repoName);
             console.log(`Related PRs for issue #${issue.number}: ${relatedPRs.map(event => event.id).join(', ')}`);
@@ -587,7 +587,21 @@ async function run() {
 
                 for (const pr of sortedMergedPRs) {
                     if (!await isPrLinkedToIssue(octokit, pr.number, repoOwner, repoName)) {
-                        mergedPRsWithoutLinkToIssue += await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
+                        let releaseNotes = await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
+                        let foundUserLabels = false;
+                        if (chaptersToPRWithoutIssue) {
+                            titlesToLabelsMap.forEach((labels, title) => {
+                                if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
+                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                    foundUserLabels = true;
+                                }
+                            });
+                        }
+
+                        if (!foundUserLabels) {
+                            mergedPRsWithoutLinkToIssue += releaseNotes;
+                        }
+
                         console.log(`DEBUG: value if mergedPRsWithoutLinkToIssue: ${mergedPRsWithoutLinkToIssue}`);
                     } else {
                         if (await isPrLinkedToOpenIssue(octokit, pr.number, repoOwner, repoName)) {
@@ -607,7 +621,20 @@ async function run() {
 
                 for (const pr of sortedClosedPRs) {
                     if (!await isPrLinkedToIssue(octokit, pr.number, repoOwner, repoName)) {
-                        closedPRsWithoutLinkToIssue += await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
+                        let releaseNotes = await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
+                        let foundUserLabels = false;
+                        if (chaptersToPRWithoutIssue) {
+                            titlesToLabelsMap.forEach((labels, title) => {
+                                if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
+                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                    foundUserLabels = true;
+                                }
+                            });
+                        }
+                        
+                        if (!foundUserLabels) {
+                            closedPRsWithoutLinkToIssue += releaseNotes;
+                        }
                     }
                 }
             } else {
@@ -640,16 +667,16 @@ async function run() {
                 releaseNotes += "### Closed Issues without Pull Request ⚠️\n" + (closedIssuesWithoutPR || "All closed issues linked to a Pull Request.") + "\n\n";
                 releaseNotes += "### Closed Issues without User Defined Labels ⚠️\n" + (closedIssuesWithoutUserLabels || "All closed issues contain at least one of user defined labels.") + "\n\n";
                 releaseNotes += "### Closed Issues without Release Notes ⚠️\n" + (closedIssuesWithoutReleaseNotes || "All closed issues have release notes.") + "\n\n";
-                releaseNotes += "### Merged PRs without Linked Issue ⚠️\n" + (mergedPRsWithoutLinkToIssue || "All merged PRs are linked to issues.") + "\n\n";
+                releaseNotes += "### Merged PRs without Linked Issue and Custom Labels ⚠️\n" + (mergedPRsWithoutLinkToIssue || "All merged PRs are linked to issues.") + "\n\n";
                 releaseNotes += "### Merged PRs Linked to Open Issue ⚠️\n" + (mergedPRsLinkedToOpenIssue || "All merged PRs are linked to Closed issues.") + "\n\n";
-                releaseNotes += "### Closed PRs without Linked Issue ⚠️\n" + (closedPRsWithoutLinkToIssue || "All closed PRs are linked to issues.") + "\n\n";
+                releaseNotes += "### Closed PRs without Linked Issue and Custom Labels ⚠️\n" + (closedPRsWithoutLinkToIssue || "All closed PRs are linked to issues.") + "\n\n";
             } else {
                 releaseNotes += closedIssuesWithoutPR ? "### Closed Issues without Pull Request ⚠️\n" + closedIssuesWithoutPR + "\n\n" : "";
                 releaseNotes += closedIssuesWithoutUserLabels ? "### Closed Issues without User Defined Labels ⚠️\n" + closedIssuesWithoutUserLabels + "\n\n" : "";
                 releaseNotes += closedIssuesWithoutReleaseNotes ? "### Closed Issues without Release Notes ⚠️\n" + closedIssuesWithoutReleaseNotes + "\n\n" : "";
-                releaseNotes += mergedPRsWithoutLinkToIssue ? "### Merged PRs without Link to Issue ⚠️\n" + mergedPRsWithoutLinkToIssue + "\n\n" : "";
+                releaseNotes += mergedPRsWithoutLinkToIssue ? "### Merged PRs without Link to Issue and Custom Labels ⚠️\n" + mergedPRsWithoutLinkToIssue + "\n\n" : "";
                 releaseNotes += mergedPRsLinkedToOpenIssue ? "### Merged PRs Linked to Open Issue ⚠️\n" + mergedPRsLinkedToOpenIssue + "\n\n" : "";
-                releaseNotes += closedPRsWithoutLinkToIssue ? "### Closed PRs without Link to Issue ⚠️\n" + closedPRsWithoutLinkToIssue + "\n\n" : "";
+                releaseNotes += closedPRsWithoutLinkToIssue ? "### Closed PRs without Link to Issue and Custom Labels ⚠️\n" + closedPRsWithoutLinkToIssue + "\n\n" : "";
             }
         }
         releaseNotes += "#### Full Changelog\n" + changelogUrl;

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -487,6 +487,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN;
     const tagName = core.getInput('tag-name');
     const githubRepository = process.env.GITHUB_REPOSITORY;
+    const duplicate = "- **<span style=\"color: red;\">[Duplicate]<span>** #";
 
     // Validate GitHub token
     if (!githubToken) {
@@ -561,8 +562,12 @@ async function run() {
             let foundUserLabels = false;
             titlesToLabelsMap.forEach((labels, title) => {
                 if (labels.some(label => issue.labels.map(l => l.name).includes(label))) {
-                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                    foundUserLabels = true;
+                    if (foundUserLabels) {
+                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                    } else {
+                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                        foundUserLabels = true;
+                    }
                 }
             });
 
@@ -592,8 +597,12 @@ async function run() {
                         if (chaptersToPRWithoutIssue) {
                             titlesToLabelsMap.forEach((labels, title) => {
                                 if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
-                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                                    foundUserLabels = true;
+                                    if (foundUserLabels) {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                                    } else {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                        foundUserLabels = true;
+                                    }
                                 }
                             });
                         }
@@ -626,12 +635,16 @@ async function run() {
                         if (chaptersToPRWithoutIssue) {
                             titlesToLabelsMap.forEach((labels, title) => {
                                 if (labels.some(label => pr.labels.map(l => l.name).includes(label))) {
-                                    chapterContents.set(title, chapterContents.get(title) + releaseNotes);
-                                    foundUserLabels = true;
+                                    if (foundUserLabels) {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes.replace(/^- #/, duplicate));
+                                    } else {
+                                        chapterContents.set(title, chapterContents.get(title) + releaseNotes);
+                                        foundUserLabels = true;
+                                    }
                                 }
                             });
                         }
-                        
+
                         if (!foundUserLabels) {
                             closedPRsWithoutLinkToIssue += releaseNotes;
                         }

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -67,7 +67,29 @@ async function getIssueContributors(issueAssignees, commitAuthors) {
 }
 
 /**
- * Retrieves authors of commits from pull requests related to an issue.
+ * Fetches contributors for a pull request.
+ * @param {Array} prAssignees - List of assignees for the pull requests.
+ * @param {Array} commitAuthors - List of authors of commits.
+ * @returns {Set<string>} A set of contributors' usernames.
+ */
+async function getPRContributors(prAssignees, commitAuthors) {
+    // Map the prAssignees to the required format
+    const assignees = prAssignees.map(assignee => '@' + assignee.login);
+
+    // Combine the assignees and commit authors
+    const combined = [...assignees, ...commitAuthors];
+
+    // Check if the combined array is empty
+    if (combined && combined.length === 0) {
+        return new Set(["\"Missing Assignee or Contributor\""]);
+    }
+
+    // If not empty, return the Set of combined values
+    return new Set(combined);
+}
+
+/**
+ * Retrieves authors of commits from pull requests.
  * @param {Octokit} octokit - The Octokit instance.
  * @param {string} repoOwner - The owner of the repository.
  * @param {string} repoName - The name of the repository.
@@ -77,40 +99,58 @@ async function getIssueContributors(issueAssignees, commitAuthors) {
 async function getPRCommitAuthors(octokit, repoOwner, repoName, relatedPRs) {
     let commitAuthors = new Set();
     for (const event of relatedPRs) {
-        const prNumber = event.source.issue.number;
-        const commits = await octokit.rest.pulls.listCommits({
-            owner: repoOwner,
-            repo: repoName,
-            pull_number: prNumber
-        });
+        const authors = await getPRCommitAuthorsByPRNumber(octokit, repoOwner, repoName, event.source.issue.number);
+        for (const author of authors) {
+            commitAuthors.add(author);
+        }
+    }
 
-        for (const commit of commits.data) {
-            commitAuthors.add('@' + commit.author.login);
+    return commitAuthors;
+}
 
-            const coAuthorMatches = commit.commit.message.match(/Co-authored-by: (.+ <.+>)/gm);
-            if (coAuthorMatches) {
-                for (const coAuthorLine of coAuthorMatches) {
-                    const emailRegex = /<([^>]+)>/;
-                    const nameRegex = /Co-authored-by: (.+) </;
-                    const emailMatch = emailRegex.exec(coAuthorLine);
-                    const nameMatch = nameRegex.exec(coAuthorLine);
-                    if (emailMatch && nameMatch) {
-                        const email = emailMatch[1];
-                        const name = nameMatch[1].trim();
+/**
+ * Retrieves authors of commits from pull request.
+ * @param {Octokit} octokit - The Octokit instance.
+ * @param {string} repoOwner - The owner of the repository.
+ * @param {string} repoName - The name of the repository.
+ * @param {number} prNumber - The pull request number.
+ * @returns {Set<string>} A set of commit authors' usernames.
+ */
+async function getPRCommitAuthorsByPRNumber(octokit, repoOwner, repoName, prNumber) {
+    let commitAuthors = new Set();
 
-                        console.log(`Searching for GitHub user with email: ${email}`);
+    const commits = await octokit.rest.pulls.listCommits({
+        owner: repoOwner,
+        repo: repoName,
+        pull_number: prNumber
+    });
 
-                        const searchResult = await octokit.rest.search.users({
-                            q: `${email} in:email`
-                        });
+    for (const commit of commits.data) {
+        commitAuthors.add('@' + commit.author.login);
 
-                        const user = searchResult.data.items[0];
-                        if (user && user.login) {
-                            commitAuthors.add('@' + user.login);
-                        } else {
-                            console.log(`No public GitHub account found for email: ${email}`);
-                            commitAuthors.add(name);
-                        }
+        const coAuthorMatches = commit.commit.message.match(/Co-authored-by: (.+ <.+>)/gm);
+        if (coAuthorMatches) {
+            for (const coAuthorLine of coAuthorMatches) {
+                const emailRegex = /<([^>]+)>/;
+                const nameRegex = /Co-authored-by: (.+) </;
+                const emailMatch = emailRegex.exec(coAuthorLine);
+                const nameMatch = nameRegex.exec(coAuthorLine);
+                if (emailMatch && nameMatch) {
+                    const email = emailMatch[1];
+                    const name = nameMatch[1].trim();
+
+                    console.log(`Searching for GitHub user with email: ${email}`);
+
+                    const searchResult = await octokit.rest.search.users({
+                        q: `${email} in:email`
+                    });
+
+                    const user = searchResult.data.items[0];
+                    if (user && user.login) {
+                        commitAuthors.add('@' + user.login);
+                    } else {
+                        console.log(`No public GitHub account found for email: ${email}`);
+                        commitAuthors.add(name);
                     }
                 }
             }
@@ -130,6 +170,22 @@ async function getPRCommitAuthors(octokit, repoOwner, repoName, relatedPRs) {
  */
 async function getIssueComments(octokit, issueNumber, repoOwner, repoName) {
     return await octokit.rest.issues.listComments({owner: repoOwner, repo: repoName, issue_number: issueNumber});
+}
+
+/**
+ * Fetches comments for a specific pull request.
+ * @param {Octokit} octokit - The Octokit instance.
+ * @param {number} prNumber - The pull request number.
+ * @param {string} repoOwner - The owner of the repository.
+ * @param {string} repoName - The name of the repository.
+ * @returns {Promise<Array>} An array of pull request comments.
+ */
+async function getPRComments(octokit, prNumber, repoOwner, repoName) {
+    return await octokit.rest.pulls.listReviewComments({
+        owner: repoOwner,
+        repo: repoName,
+        pull_number: prNumber
+    });
 }
 
 /**
@@ -172,22 +228,71 @@ async function getReleaseNotesFromComments(octokit, issueNumber, issueTitle, iss
         }
     }
 
+    const contributorsList = Array.from(contributors).join(', ');
     if (releaseNotes.length === 0) {
         console.log(`No specific release notes found in comments for issue #${issueNumber}`);
-        const contributorsList = Array.from(contributors).join(', ');
         if (relatedPRs.length === 0) {
             return `- x#${issueNumber} _${issueTitle}_ implemented by ${contributorsList}\n`;
         } else {
             return `- x#${issueNumber} _${issueTitle}_ implemented by ${contributorsList} in ${relatedPRLinksString}\n`;
         }
     } else {
-        const contributorsList = Array.from(contributors).join(', ');
         const notes = releaseNotes.join('\n');
         if (relatedPRs.length === 0) {
             return `- #${issueNumber} _${issueTitle}_ implemented by ${contributorsList}\n${notes}\n`;
         } else {
             return `- #${issueNumber} _${issueTitle}_ implemented by ${contributorsList} in ${relatedPRLinksString}\n${notes}\n`;
         }
+    }
+}
+
+/**
+ * Generates release notes from pull request comments.
+ * @param {Octokit} octokit - The Octokit instance.
+ * @param {number} prNumber - The issue number.
+ * @param {string} prTitle - The title of the issue.
+ * @param {Array} prAssignees - List of assignees for the issue.
+ * @param {string} repoOwner - The owner of the repository.
+ * @param {string} repoName - The name of the repository.
+ * @returns {Promise<string>} The formatted release note for the issue.
+ */
+async function getReleaseNotesFromPRComments(octokit, prNumber, prTitle, prAssignees, repoOwner, repoName) {
+    console.log(`Fetching release notes from comments for pull request #${prNumber}`);
+    const comments = await getPRComments(octokit, prNumber, repoOwner, repoName);
+    let commitAuthors = await getPRCommitAuthorsByPRNumber(octokit, repoOwner, repoName, prNumber);
+    let contributors = await getPRContributors(prAssignees, commitAuthors);
+
+    // TODO candidate for refactoring - duplicite
+    let releaseNotes = [];
+    for (const comment of comments.data) {
+        if (comment.body.toLowerCase().startsWith('release notes')) {
+            const noteContent = comment.body.replace(/^release notes:?.*(\r\n|\n|\r)?/i, '').trim();
+            console.log(`Found release notes in comments for pull request #${prNumber}`);
+
+            // Process each line of the noteContent
+            const processedContent = noteContent.split(/\r?\n/).map(line => {
+                // Check if the line starts with "  -"
+                if (!line.startsWith("-")) {
+                    // Remove leading whitespace and prepend "  - "
+                    return "  - " + line.trim();
+                } else {
+                    // Remove leading whitespace
+                    return line.replace(/^\s*[\r\n]/gm, '').replace(/^/gm, '  ');
+                }
+            }).join('\n');
+
+            releaseNotes.push(processedContent);
+        }
+    }
+
+    const contributorsList = Array.from(contributors).join(', ');
+    if (releaseNotes.length === 0) {
+        console.log(`No specific release notes found in comments for pull request #${prNumber}`);
+        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n`;
+    } else {
+        console.log(`Release notes: ${releaseNotes}`);
+        const notes = releaseNotes.join('\n');
+        return `- #${prNumber} _${prTitle}_ implemented by ${contributorsList}\n${notes}\n`;
     }
 }
 
@@ -437,6 +542,7 @@ async function run() {
     const skipLabel = core.getInput('skip-release-notes-label') || 'skip-release-notes';
     const usePublishedAt = core.getInput('published-at') ? core.getInput('published-at').toLowerCase() === 'true' : false;
     const printEmptyChapters = core.getInput('print-empty-chapters') ? core.getInput('print-empty-chapters').toLowerCase() === 'true' : true;
+    const chaptersToPRWithoutIssue = core.getInput('chapters-to-pr-without-issue') ? core.getInput('chapters-to-pr-without-issue').toLowerCase() === 'true' : true;
 
     const octokit = new Octokit({ auth: githubToken });
 
@@ -454,8 +560,8 @@ async function run() {
         // Initialize variables for each chapter
         const titlesToLabelsMap = parseChaptersJson(chaptersJson);
         const chapterContents = new Map(Array.from(titlesToLabelsMap.keys()).map(label => [label, '']));
-        let closedIssuesWithoutReleaseNotes = '', closedIssuesWithoutUserLabels = '', closedIssuesWithoutPR = '', mergedPRsWithoutLinkedIssue = '';
-        let mergedPRsLinkedToOpenIssue = '', closedPRsLinkedToIssue = '';
+        let closedIssuesWithoutReleaseNotes = '', closedIssuesWithoutUserLabels = '', closedIssuesWithoutPR = '', mergedPRsWithoutLinkToIssue = '';
+        let mergedPRsLinkedToOpenIssue = '', closedPRsWithoutLinkToIssue = '';
 
         // Categorize issues and PRs
         for (const issue of closedIssuesOnlyIssues) {
@@ -503,10 +609,11 @@ async function run() {
 
                 for (const pr of sortedMergedPRs) {
                     if (!await isPrLinkedToIssue(octokit, pr.number, repoOwner, repoName)) {
-                        mergedPRsWithoutLinkedIssue += `#${pr.number} _${pr.title}_\n`;
+                        mergedPRsWithoutLinkToIssue += await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
+                        console.log(`DEBUG: value if mergedPRsWithoutLinkToIssue: ${mergedPRsWithoutLinkToIssue}`);
                     } else {
                         if (await isPrLinkedToOpenIssue(octokit, pr.number, repoOwner, repoName)) {
-                            mergedPRsLinkedToOpenIssue += `#${pr.number} _${pr.title}_\n`;
+                            mergedPRsLinkedToOpenIssue += `- #${pr.number} _${pr.title}_\n`;
                         }
                     }
                 }
@@ -522,7 +629,7 @@ async function run() {
 
                 for (const pr of sortedClosedPRs) {
                     if (!await isPrLinkedToIssue(octokit, pr.number, repoOwner, repoName)) {
-                        closedPRsLinkedToIssue += `#${pr.number} _${pr.title}_\n`;
+                        closedPRsWithoutLinkToIssue += await getReleaseNotesFromPRComments(octokit, pr.number, pr.title, pr.assignees, repoOwner, repoName);
                     }
                 }
             } else {
@@ -555,16 +662,16 @@ async function run() {
                 releaseNotes += "### Closed Issues without Pull Request ⚠️\n" + (closedIssuesWithoutPR || "All closed issues linked to a Pull Request.") + "\n\n";
                 releaseNotes += "### Closed Issues without User Defined Labels ⚠️\n" + (closedIssuesWithoutUserLabels || "All closed issues contain at least one of user defined labels.") + "\n\n";
                 releaseNotes += "### Closed Issues without Release Notes ⚠️\n" + (closedIssuesWithoutReleaseNotes || "All closed issues have release notes.") + "\n\n";
-                releaseNotes += "### Merged PRs without Linked Issue ⚠️\n" + (mergedPRsWithoutLinkedIssue || "All merged PRs are linked to issues.") + "\n\n";
+                releaseNotes += "### Merged PRs without Linked Issue ⚠️\n" + (mergedPRsWithoutLinkToIssue || "All merged PRs are linked to issues.") + "\n\n";
                 releaseNotes += "### Merged PRs Linked to Open Issue ⚠️\n" + (mergedPRsLinkedToOpenIssue || "All merged PRs are linked to Closed issues.") + "\n\n";
-                releaseNotes += "### Closed PRs without Linked Issue ⚠️\n" + (closedPRsLinkedToIssue || "All closed PRs are linked to issues.") + "\n\n";
+                releaseNotes += "### Closed PRs without Linked Issue ⚠️\n" + (closedPRsWithoutLinkToIssue || "All closed PRs are linked to issues.") + "\n\n";
             } else {
                 releaseNotes += closedIssuesWithoutPR ? "### Closed Issues without Pull Request ⚠️\n" + closedIssuesWithoutPR + "\n\n" : "";
                 releaseNotes += closedIssuesWithoutUserLabels ? "### Closed Issues without User Defined Labels ⚠️\n" + closedIssuesWithoutUserLabels + "\n\n" : "";
                 releaseNotes += closedIssuesWithoutReleaseNotes ? "### Closed Issues without Release Notes ⚠️\n" + closedIssuesWithoutReleaseNotes + "\n\n" : "";
-                releaseNotes += mergedPRsWithoutLinkedIssue ? "### Merged PRs without Linked Issue ⚠️\n" + mergedPRsWithoutLinkedIssue + "\n\n" : "";
+                releaseNotes += mergedPRsWithoutLinkToIssue ? "### Merged PRs without Link to Issue ⚠️\n" + mergedPRsWithoutLinkToIssue + "\n\n" : "";
                 releaseNotes += mergedPRsLinkedToOpenIssue ? "### Merged PRs Linked to Open Issue ⚠️\n" + mergedPRsLinkedToOpenIssue + "\n\n" : "";
-                releaseNotes += closedPRsLinkedToIssue ? "### Closed PRs without Linked Issue ⚠️\n" + closedPRsLinkedToIssue + "\n\n" : "";
+                releaseNotes += closedPRsWithoutLinkToIssue ? "### Closed PRs without Link to Issue ⚠️\n" + closedPRsWithoutLinkToIssue + "\n\n" : "";
             }
         }
         releaseNotes += "#### Full Changelog\n" + changelogUrl;

--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -487,7 +487,7 @@ async function run() {
     const githubToken = process.env.GITHUB_TOKEN;
     const tagName = core.getInput('tag-name');
     const githubRepository = process.env.GITHUB_REPOSITORY;
-    const duplicate = "- **<span style=\"color: red;\">[Duplicate]<span>** #";
+    const duplicate = "- _**[Duplicate]**_ #";
 
     // Validate GitHub token
     if (!githubToken) {


### PR DESCRIPTION
#26 - Introduce the idea of PR without Issue as part for user-defined chapters
- removed code duplication from logic extension "extraction of Release"
- fix similar methods to get issues and PR contributors
- Implemented logic to add PR without linked issue to custom chapters
- Add logic that marks duplication of records in customer-defined chapters

Closes #26 