### PR TITLE
Add black and pylint exclude configuration for black and pylint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -116,6 +116,11 @@ unsafe-load-any-extension=no
 #verbose=
 
 
+[MASTER]
+
+ignore-paths=tests
+
+
 [BASIC]
 
 # Naming style matching correct argument names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [tool.black]
 line-length = 120
 target-version = ['py311']
+force-exclude = '''test'''
+
+[tool.coverage.run]
+omit = ["tests/*"]


### PR DESCRIPTION
- Introduced exclusion logic for black and pylint tools.
- The directory tests will be ignored.

Release notes:
* Add exclusion for tests folder in black and pylint tools.