### PR TITLE
Remove no used action input

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,6 @@ Generate Release Notes action is dedicated to enhance the quality and organizati
 - **Required**: No
 - **Default**: true (Empty chapters are printed.)
 
-### `chapters-to-pr-without-issue`
-- **Description**: Set it to false to avoid the application of custom chapters for PRs without linked issues.
-- **Required**: No
-- **Default**: true (Custom chapters are applied to PRs without linked issues.)
-
-
 ## Outputs
 The output of the action is a markdown string containing the release notes for the specified tag. This string can be used in subsequent steps to publish the release notes to a file, create a GitHub release, or send notifications.
 
@@ -165,7 +159,6 @@ Add the following step to your GitHub workflow (in example are used non-default 
 
     warnings: false
     print-empty-chapters: false
-    chapters-to-pr-without-issue: false
 ```
 
 ## Features
@@ -382,7 +375,6 @@ export INPUT_WARNINGS="true"
 export INPUT_PUBLISHED_AT="true"
 export INPUT_SKIP_RELEASE_NOTES_LABEL="ignore-in-release"
 export INPUT_PRINT_EMPTY_CHAPTERS="true"
-export INPUT_CHAPTERS_TO_PR_WITHOUT_ISSUE="true"
 export INPUT_VERBOSE="true"
 
 # CI in-build variables

--- a/action.yml
+++ b/action.yml
@@ -47,10 +47,6 @@ inputs:
     description: 'Print chapters even if they are empty.'
     required: false
     default: 'true'
-  chapters-to-pr-without-issue:
-    description: 'Apply custom chapters for PRs without linked issues.'
-    required: false
-    default: 'true'
   verbose:
     description: 'Print verbose logs.'
     required: false
@@ -118,7 +114,6 @@ runs:
         INPUT_PUBLISHED_AT: ${{ inputs.published-at }}
         INPUT_SKIP_RELEASE_NOTES_LABEL: ${{ inputs.skip-release-notes-label }}
         INPUT_PRINT_EMPTY_CHAPTERS: ${{ inputs.print-empty-chapters }}
-        INPUT_CHAPTERS_TO_PR_WITHOUT_ISSUE: ${{ inputs.chapters-to-pr-without-issue }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_GITHUB_REPOSITORY: ${{ github.repository }}
         INPUT_ROW_FORMAT_ISSUE: ${{ inputs.row-format-issue }}

--- a/release_notes_generator/action_inputs.py
+++ b/release_notes_generator/action_inputs.py
@@ -34,7 +34,6 @@ from release_notes_generator.utils.constants import (
     WARNINGS,
     RUNNER_DEBUG,
     PRINT_EMPTY_CHAPTERS,
-    CHAPTERS_TO_PR_WITHOUT_ISSUE,
     DUPLICITY_SCOPE,
     DUPLICITY_ICON,
     ROW_FORMAT_LINK_PR,
@@ -139,13 +138,6 @@ class ActionInputs:
         return get_action_input(PRINT_EMPTY_CHAPTERS, "true").lower() == "true"
 
     @staticmethod
-    def get_chapters_to_pr_without_issue() -> bool:
-        """
-        Get the chapters to PR without issue parameter value from the action inputs.
-        """
-        return get_action_input(CHAPTERS_TO_PR_WITHOUT_ISSUE, "true").lower() == "true"
-
-    @staticmethod
     def validate_input(input_value, expected_type: type, error_message: str, error_buffer: list) -> bool:
         """
         Validates the input value against the expected type.
@@ -246,11 +238,6 @@ class ActionInputs:
         print_empty_chapters = ActionInputs.get_print_empty_chapters()
         ActionInputs.validate_input(print_empty_chapters, bool, "Print empty chapters must be a boolean.", errors)
 
-        chapters_to_pr_without_issue = ActionInputs.get_chapters_to_pr_without_issue()
-        ActionInputs.validate_input(
-            chapters_to_pr_without_issue, bool, "Chapters to PR without issue must be a boolean.", errors
-        )
-
         # Log errors if any
         if errors:
             for error in errors:
@@ -265,4 +252,3 @@ class ActionInputs:
         logger.debug("Verbose logging: %s", verbose)
         logger.debug("Warnings: %s", warnings)
         logger.debug("Print empty chapters: %s", print_empty_chapters)
-        logger.debug("Chapters to PR without issue: %s", chapters_to_pr_without_issue)

--- a/release_notes_generator/utils/constants.py
+++ b/release_notes_generator/utils/constants.py
@@ -37,7 +37,6 @@ SUPPORTED_ROW_FORMAT_KEYS = ["number", "title", "pull-requests"]
 # Features
 WARNINGS = "warnings"
 PRINT_EMPTY_CHAPTERS = "print-empty-chapters"
-CHAPTERS_TO_PR_WITHOUT_ISSUE = "chapters-to-pr-without-issue"
 
 # Pull Request states
 PR_STATE_CLOSED = "closed"

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -29,7 +29,6 @@ success_case = {
     "get_published_at": False,
     "get_skip_release_notes_label": "skip",
     "get_print_empty_chapters": True,
-    "get_chapters_to_pr_without_issue": False,
     "get_verbose": True,
 }
 
@@ -42,7 +41,6 @@ failure_cases = [
     ("get_published_at", "not_bool", "Published at must be a boolean."),
     ("get_skip_release_notes_label", "", "Skip release notes label must be a non-empty string."),
     ("get_print_empty_chapters", "not_bool", "Print empty chapters must be a boolean."),
-    ("get_chapters_to_pr_without_issue", "not_bool", "Chapters to PR without issue must be a boolean."),
     ("get_verbose", "not_bool", "Verbose logging must be a boolean."),
     ("get_duplicity_icon", "", "Duplicity icon must be a non-empty string and have a length of 1."),
     ("get_duplicity_icon", "Oj", "Duplicity icon must be a non-empty string and have a length of 1."),
@@ -127,11 +125,6 @@ def test_get_skip_release_notes_label(mocker):
 def test_get_print_empty_chapters(mocker):
     mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="true")
     assert ActionInputs.get_print_empty_chapters() is True
-
-
-def test_get_chapters_to_pr_without_issue(mocker):
-    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="false")
-    assert ActionInputs.get_chapters_to_pr_without_issue() is False
 
 
 def test_get_verbose_verbose_by_action_input(mocker):


### PR DESCRIPTION
Reason: The goal to reach with this input is no more valid. Control was not used.

Release notes:
- Remove no used action input.