### PR TITLE
#117 - Already releases issue are returned from GitHub API

### DIFF
--- a/release_notes_generator/generator.py
+++ b/release_notes_generator/generator.py
@@ -79,9 +79,10 @@ class ReleaseNotesGenerator:
         rls = self._safe_call(repo.get_latest_release)()
         if rls is None:
             logger.info("Latest release not found for %s. 1st release for repository!", repo.full_name)
+        else:
+            logger.debug("RLS created_at: %s, published_at: %s", rls.created_at, rls.published_at)
 
         # default is repository creation date if no releases OR created_at of latest release
-        logger.debug("RLS created_at: %s, published_at: %s", rls.created_at, rls.published_at)
         since = rls.created_at if rls else repo.created_at
         if rls and ActionInputs.get_published_at():
             since = rls.published_at
@@ -94,7 +95,9 @@ class ReleaseNotesGenerator:
             logger.info("Starting issue, prs and commit reduction by the latest release since time.")
 
             # filter out closed Issues before the date
-            issues = list(filter(lambda issue: issue.closed_at is not None and issue.closed_at > since, list(issues_all)))
+            issues = list(
+                filter(lambda issue: issue.closed_at is not None and issue.closed_at > since, list(issues_all))
+            )
             logger.debug("Count of issues reduced from %d to %d", len(list(issues_all)), len(issues))
 
             # filter out merged PRs and commits before the date

--- a/release_notes_generator/generator.py
+++ b/release_notes_generator/generator.py
@@ -87,6 +87,7 @@ class ReleaseNotesGenerator:
         if rls and ActionInputs.get_published_at():
             since = rls.published_at
 
+        # get all issues, pulls and commits, and then reduce them by the latest release since time
         issues = issues_all = self._safe_call(repo.get_issues)(state=ISSUE_STATE_ALL, since=since)
         pulls = pulls_all = self._safe_call(repo.get_pulls)(state="closed")
         commits = commits_all = list(self._safe_call(repo.get_commits)())

--- a/release_notes_generator/generator.py
+++ b/release_notes_generator/generator.py
@@ -85,12 +85,16 @@ class ReleaseNotesGenerator:
         if rls and ActionInputs.get_published_at():
             since = rls.published_at
 
-        issues = self._safe_call(repo.get_issues)(state=ISSUE_STATE_ALL, since=since)
+        issues = issues_all = self._safe_call(repo.get_issues)(state=ISSUE_STATE_ALL, since=since)
         pulls = pulls_all = self._safe_call(repo.get_pulls)(state="closed")
         commits = commits_all = list(self._safe_call(repo.get_commits)())
 
         if rls is not None:
-            logger.info("Count of issues: %d", len(list(issues)))
+            logger.info("Starting issue, prs and commit reduction by the latest release since time.")
+
+            # filter out closed Issues before the date
+            issues = list(filter(lambda issue: issue.closed_at is not None and issue.closed_at > since, list(issues_all)))
+            logger.debug("Count of issues reduced from %d to %d", len(list(issues_all)), len(issues))
 
             # filter out merged PRs and commits before the date
             pulls = list(filter(lambda pull: pull.merged_at is not None and pull.merged_at > since, list(pulls_all)))

--- a/release_notes_generator/generator.py
+++ b/release_notes_generator/generator.py
@@ -81,6 +81,7 @@ class ReleaseNotesGenerator:
             logger.info("Latest release not found for %s. 1st release for repository!", repo.full_name)
 
         # default is repository creation date if no releases OR created_at of latest release
+        logger.debug("RLS created_at: %s, published_at: %s", rls.created_at, rls.published_at)
         since = rls.created_at if rls else repo.created_at
         if rls and ActionInputs.get_published_at():
             since = rls.published_at

--- a/tests/test_release_notes_generator.py
+++ b/tests/test_release_notes_generator.py
@@ -61,6 +61,7 @@ def test_generate_release_notes_latest_release_not_found(
 
     mock_issue_closed.created_at = mock_repo.created_at + timedelta(days=2)
     mock_issue_closed_i1_bug.created_at = mock_repo.created_at + timedelta(days=7)
+    mock_issue_closed_i1_bug.closed_at = mock_repo.created_at + timedelta(days=6)
     mock_pull_closed_with_rls_notes_101.merged_at = mock_repo.created_at + timedelta(days=2)
     mock_pull_closed_with_rls_notes_102.merged_at = mock_repo.created_at + timedelta(days=7)
 
@@ -94,6 +95,7 @@ def test_generate_release_notes_latest_release_found_by_created_at(
     github_mock = mocker.Mock(spec=Github)
     github_mock.get_repo.return_value = mock_repo
     mock_repo.created_at = datetime.now() - timedelta(days=10)
+    mock_repo.published_at = datetime.now() - timedelta(days=9)
 
     mock_repo.get_issues.return_value = [mock_issue_closed_i1_bug]
     mock_repo.get_pulls.return_value = [mock_pull_closed_with_rls_notes_101, mock_pull_closed_with_rls_notes_102]
@@ -101,6 +103,7 @@ def test_generate_release_notes_latest_release_found_by_created_at(
     mock_commit.commit.author.date = mock_repo.created_at + timedelta(days=1)
 
     mock_issue_closed_i1_bug.created_at = mock_repo.created_at + timedelta(days=7)
+    mock_issue_closed_i1_bug.closed_at = mock_repo.created_at + timedelta(days=6)
     mock_pull_closed_with_rls_notes_101.merged_at = mock_repo.created_at + timedelta(days=2)
     mock_pull_closed_with_rls_notes_102.merged_at = mock_repo.created_at + timedelta(days=7)
 
@@ -148,7 +151,7 @@ def test_generate_release_notes_latest_release_found_by_published_at(
     mock_commit.commit.author.date = mock_repo.created_at + timedelta(days=1)
 
     mock_issue_closed_i1_bug.created_at = mock_repo.created_at + timedelta(days=7)
-    mock_issue_closed_i1_bug.published_at = mock_repo.created_at + timedelta(days=8)
+    mock_issue_closed_i1_bug.closed_at = mock_repo.created_at + timedelta(days=8)
     mock_pull_closed_with_rls_notes_101.merged_at = mock_repo.created_at + timedelta(days=2)
     mock_pull_closed_with_rls_notes_102.merged_at = mock_repo.created_at + timedelta(days=7)
 


### PR DESCRIPTION
Release Notes:
- Added new filtration logic for received issues from GH API. These issues should already be filtered, but there is an error.

Closes #117 