### PR TITLE
#128 - Allow to skip patch version in input assuming 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Add the following step to your GitHub workflow (in example are used non-default 
   env:
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
   with:
-    tag-name: "v0.2.0"
-    from-tag-name: "v0.1.0"
+    tag-name: "v0.2.0"                        # accepts also v0.2 format when patch version is 0
+    from-tag-name: "v0.1.0"                   # accepts also v0.1 format when patch version is 0
     chapters: |
       - {"title": "Breaking Changes 💥", "label": "breaking-change"}
       - {"title": "New Features 🎉", "label": "enhancement"}

--- a/release_notes_generator/action_inputs.py
+++ b/release_notes_generator/action_inputs.py
@@ -52,7 +52,7 @@ from release_notes_generator.utils.constants import (
 )
 from release_notes_generator.utils.enums import DuplicityScopeEnum
 from release_notes_generator.utils.gh_action import get_action_input
-from release_notes_generator.utils.utils import _normalize_version_tag
+from release_notes_generator.utils.utils import normalize_version_tag
 
 logger = logging.getLogger(__name__)
 
@@ -121,7 +121,7 @@ class ActionInputs:
         Get the tag name from the action inputs.
         """
         raw = get_action_input(TAG_NAME) or ""
-        return _normalize_version_tag(raw)
+        return normalize_version_tag(raw)
 
     @staticmethod
     def get_from_tag_name() -> str:
@@ -129,7 +129,7 @@ class ActionInputs:
         Get the from-tag name from the action inputs.
         """
         raw = get_action_input(FROM_TAG_NAME, default="")
-        return _normalize_version_tag(raw)  # type: ignore[arg-type]
+        return normalize_version_tag(raw)  # type: ignore[arg-type]
 
     @staticmethod
     def is_from_tag_name_defined() -> bool:

--- a/release_notes_generator/action_inputs.py
+++ b/release_notes_generator/action_inputs.py
@@ -52,6 +52,7 @@ from release_notes_generator.utils.constants import (
 )
 from release_notes_generator.utils.enums import DuplicityScopeEnum
 from release_notes_generator.utils.gh_action import get_action_input
+from release_notes_generator.utils.utils import _normalize_version_tag
 
 logger = logging.getLogger(__name__)
 
@@ -119,14 +120,16 @@ class ActionInputs:
         """
         Get the tag name from the action inputs.
         """
-        return get_action_input(TAG_NAME) or ""
+        raw = get_action_input(TAG_NAME) or ""
+        return _normalize_version_tag(raw)
 
     @staticmethod
     def get_from_tag_name() -> str:
         """
         Get the from-tag name from the action inputs.
         """
-        return get_action_input(FROM_TAG_NAME, default="")  # type: ignore[return-value] # string is returned as default
+        raw = get_action_input(FROM_TAG_NAME, default="")
+        return _normalize_version_tag(raw)  # type: ignore[arg-type]
 
     @staticmethod
     def is_from_tag_name_defined() -> bool:
@@ -416,6 +419,7 @@ class ActionInputs:
 
         logger.debug("Repository: %s/%s", ActionInputs._owner, ActionInputs._repo_name)
         logger.debug("Tag name: %s", tag_name)
+        logger.debug("From tag name: %s", from_tag_name)
         logger.debug("Chapters: %s", chapters)
         logger.debug("Published at: %s", published_at)
         logger.debug("Skip release notes labels: %s", ActionInputs.get_skip_release_notes_labels())

--- a/release_notes_generator/utils/utils.py
+++ b/release_notes_generator/utils/utils.py
@@ -71,7 +71,7 @@ _SEMVER_SHORT_RE = re.compile(
 )
 
 
-def _normalize_version_tag(tag: str) -> str:
+def normalize_version_tag(tag: str) -> str:
     """
     Normalize a tag to full 'vMAJOR.MINOR.PATCH' form.
 

--- a/tests/test_action_inputs.py
+++ b/tests/test_action_inputs.py
@@ -108,9 +108,58 @@ def test_get_github_token(mocker):
     assert ActionInputs.get_github_token() == "fake-token"
 
 
-def test_get_tag_name(mocker):
+def test_get_tag_name_version_full(mocker):
     mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.0.0")
     assert ActionInputs.get_tag_name() == "v1.0.0"
+
+
+def test_get_tag_name_version_shorted_with_v(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.2")
+    assert ActionInputs.get_tag_name() == "v1.2.0"
+
+
+def test_get_tag_name_version_shorted_no_v(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="1.2")
+    assert ActionInputs.get_tag_name() == "v1.2.0"
+
+
+def test_get_tag_name_empty(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="")
+    assert ActionInputs.get_tag_name() == ""
+
+
+def test_get_tag_name_invalid_format(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.2.beta")
+    with pytest.raises(ValueError) as excinfo:
+        ActionInputs.get_tag_name()
+    assert "Invalid version tag format: 'v1.2.beta'. Expected vMAJOR.MINOR[.PATCH], e.g. 'v0.2' or 'v0.2.0'." in str(excinfo.value)
+
+
+def test_get_tag_from_name_version_full(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.0.0")
+    assert ActionInputs.get_from_tag_name() == "v1.0.0"
+
+
+def test_get_from_tag_name_version_shorted_with_v(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.2")
+    assert ActionInputs.get_from_tag_name() == "v1.2.0"
+
+
+def test_get_from_tag_name_version_shorted_no_v(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="1.2")
+    assert ActionInputs.get_from_tag_name() == "v1.2.0"
+
+
+def test_get_from_tag_name_empty(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="")
+    assert ActionInputs.get_from_tag_name() == ""
+
+
+def test_get_from_tag_name_invalid_format(mocker):
+    mocker.patch("release_notes_generator.action_inputs.get_action_input", return_value="v1.2.beta")
+    with pytest.raises(ValueError) as excinfo:
+        ActionInputs.get_from_tag_name()
+    assert "Invalid version tag format: 'v1.2.beta'. Expected vMAJOR.MINOR[.PATCH], e.g. 'v0.2' or 'v0.2.0'." in str(excinfo.value)
 
 
 def test_get_chapters_success(mocker):


### PR DESCRIPTION
Release Notes:
- tag and from-tag inputs can be now defined as short versions. The `.0` is added automatically.

Fixes #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accepts shortened version tags (e.g., v1.2 or 1.2) and normalizes them to vMAJOR.MINOR.PATCH (e.g., v1.2.0).
  * Empty version inputs are handled gracefully (returned as empty).
  * Inputs for both primary and "from" tags are consistently normalized.

* **Bug Fixes**
  * Clearer validation errors for malformed tags (e.g., v1.2.beta).

* **Documentation**
  * README usage examples clarify accepted version formats when patch is 0.

* **Tests**
  * Expanded test coverage for version tag parsing: full, shortened, empty, and invalid inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
