### PR TITLE
#195 - Update rules for service chapter "Merged PRs Linked to 'Not Cl…

### DIFF
--- a/release_notes_generator/chapters/service_chapters.py
+++ b/release_notes_generator/chapters/service_chapters.py
@@ -220,7 +220,6 @@ class ServiceChapters(BaseChapters):
                     return
 
                 self.chapters[MERGED_PRS_LINKED_TO_NOT_CLOSED_ISSUES].add_row(record_id, record.to_chapter_row())
-                print("XXX 2")
                 self.used_record_numbers.append(record_id)
 
             if not record.is_present_in_chapters:

--- a/tests/release_notes/builder/test_release_notes_builder.py
+++ b/tests/release_notes/builder/test_release_notes_builder.py
@@ -1558,10 +1558,6 @@ def test_build_hierarchy_rls_notes_with_labels_no_type(
 
     actual_release_notes = builder.build()
 
-    print("XXX")
-    print(actual_release_notes)
-    print("XXX")
-
     assert expected_release_notes == actual_release_notes
 
 


### PR DESCRIPTION
Release Notes:
- Improved rules for deciding when hierarchy issue can be included into service chapter "Merged PRs Linked to 'Not Closed' Issue". Hierarchy issue can be open when cotains merged PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of open vs. closed issue statuses so merged PRs linked to open issues are flagged appropriately and hierarchy duplicates are avoided.
  * Consolidated messaging: when all merged PRs are linked to closed issues, release notes show a single clear statement.

* **Chores**
  * Added logging to trace skipped hierarchical entries and runtime decisions.

* **Tests**
  * Updated tests to expect the consolidated merged-PRs message and added debug traces in select tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #195 
