### PR TITLE
#194 - Add support for short v1 tag

### DIFF
--- a/.github/workflows/update_v1_tag.yml
+++ b/.github/workflows/update_v1_tag.yml
@@ -22,14 +22,8 @@ jobs:
 
       - name: Move v1 tag to this release
         run: |
-          set -euo pipefail
-          git fetch --tags --force --prune
-          TAG_NAME="${{ github.event.release.tag_name }}"
-          COMMIT_SHA="$(git rev-list -n 1 "$TAG_NAME")"
-          if [ -z "$COMMIT_SHA" ]; then
-            echo "Error: release tag '$TAG_NAME' not found or has no reachable commit."
-            exit 1
-          fi
-          echo "Release tag '$TAG_NAME' resolves to commit $COMMIT_SHA"
-          git tag -f v1 "$COMMIT_SHA"
-          git push origin --force-with-lease=refs/tags/v1 refs/tags/v1
+          git fetch --tags
+          COMMIT_SHA=$(git rev-list -n 1 ${{ github.event.release.tag_name }})
+          echo "Release tag '${{ github.event.release.tag_name }}' resolves to commit $COMMIT_SHA"
+          git tag -f v1 $COMMIT_SHA
+          git push origin -f v1


### PR DESCRIPTION
Release Notes:
- Add new workflow for automated update of v1 tag. Update will be done after release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added automation to update the v1 release tag whenever a release is published, keeping the v1 pointer aligned with the released commit.
  - Ensures download links, install scripts, and integrations that reference v1 consistently point to the intended release.
  - Infrastructure-only change; no application behavior, API, or UI changes. No action required from end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #194 
