### PR TITLE
Fix: direct commits still misclassified after #337 (compare mode)

### DIFF
--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -43,24 +43,11 @@ from release_notes_generator.utils.decorators import safe_call_decorator
 from release_notes_generator.utils.github_rate_limiter import GithubRateLimiter
 from release_notes_generator.utils.record_utils import get_id, parse_issue_id
 
-# dev note: these are GitHub-generated merge artifacts, so a match is a reliable signal that a commit
-#   is a PR merge/squash commit even if the PR itself couldn't be fetched (e.g. transient API error).
+# GitHub PR references: merge/squash markers and bare #N from rebase-merge commits
 _PR_MERGE_ARTIFACT_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)")
-# dev note: 3rd alternative catches commits whose subject leads with a bare "#N" reference
-#   (e.g. "#1403 Fix thing"), a message style left as-is by some merge strategies (e.g. rebase-merge)
-#   that don't append GitHub's "(#N)"/"Merge pull request #N" boilerplate. Without it, such PRs are
-#   never looked up at all, so their commits can't be excluded as duplicates of the PR.
-#   Unlike _PR_MERGE_ARTIFACT_RE, this is only a candidate to try fetching - #N is a common commit
-#   convention for referencing an issue and is not proof the commit belongs to a real merged PR, so it
-#   must not by itself exclude a commit (see the SHA-based check in _handle_compare_mode).
 _PR_NUMBER_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)|^#(\d+)\b")
 _COMPARE_COMMITS_MAX_RESULTS = 10_000
-# dev note: cap on how many PR-associated commit SHAs are logged at debug level, to keep verbose logs
-#   readable for large comparisons.
-_MAX_LOGGED_PR_COMMIT_SHAS = 50
-# dev note: cap on the per-commit "commit -> associated PRs" fallback lookup (see _handle_compare_mode)
-#   so a large batch of genuine direct commits can't trigger thousands of extra API calls.
-_MAX_DIRECT_COMMIT_PR_LOOKUPS = 200
+_MAX_DIRECT_COMMIT_PR_LOOKUPS = 200  # Prevent API call explosion from large commit batches
 
 logger = logging.getLogger(__name__)
 
@@ -72,10 +59,7 @@ class DataMiner:
 
     def __init__(self, github_instance: Github, rate_limiter: GithubRateLimiter):
         self.github_instance = github_instance
-        # dev note: PyGithub paginated results are lazy - the HTTP requests happen while iterating,
-        #   not on the initial call. Call sites that need a list must materialize it (e.g. via
-        #   `self._safe_call(lambda: list(x.get_foo()))()`) inside the safe-call, otherwise pagination
-        #   errors are raised outside of it and go uncaught.
+        # Lazy pagination errors must be caught inside safe_call, not propagated
         self._safe_call = safe_call_decorator(rate_limiter)
 
     def mine_data(self) -> MinedData:
@@ -177,7 +161,7 @@ class DataMiner:
         # (commits identified by PR, or belonging to a PR's commit list, are redundant with the PR itself)
         commits_without_pr: dict[GithubCommit, Repository] = {}
         for commit in compare_commits:
-            subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+            subject = self._get_commit_subject(commit)
             if commit.sha in pr_commit_shas:
                 logger.debug("Compare mode: commit %s ('%s') excluded, matched PR commit SHA.", commit.sha, subject)
                 continue
@@ -187,10 +171,7 @@ class DataMiner:
                 continue
             commits_without_pr[commit] = data.home_repository
 
-        # dev note: some merged PR's commits never reference the PR number in any commit message at all
-        #   (e.g. "Set project version to 1.8.0") so they can't be found via _extract_pr_numbers_from_commits.
-        #   As a last-resort fallback, ask GitHub directly which merged PR(s) contain each remaining
-        #   candidate "direct commit" via the commit -> PRs association endpoint.
+        # Fallback: query GitHub's commit→PR association for candidates without explicit PR refs
         if len(commits_without_pr) > _MAX_DIRECT_COMMIT_PR_LOOKUPS:
             logger.debug(
                 "Compare mode: %d commit(s) without a detected PR exceed the fallback lookup cap of %d; "
@@ -203,9 +184,7 @@ class DataMiner:
             for commit in list(commits_without_pr):
                 associated_prs = self._safe_call(lambda c=commit: list(c.get_pulls()))()
                 for pr in associated_prs or []:
-                    # dev note: the association endpoint returns a "simple" PR representation without
-                    #   `merged`, so reading it lazily completes the object via a real API call - route
-                    #   it through _safe_call like every other GitHub-hitting call in this method.
+                    # Simple PR objects need lazy-loading via _safe_call to access `merged` attribute
                     is_merged = self._safe_call(lambda p=pr: p.merged)()
                     if not is_merged or pr.number in registered_pr_numbers:
                         continue
@@ -217,7 +196,7 @@ class DataMiner:
                     self._register_pr_commit_shas(pr, pulls, pr_commit_shas, data.home_repository)
                     registered_pr_numbers.add(pr.number)
                 if commit.sha in pr_commit_shas:
-                    subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+                    subject = self._get_commit_subject(commit)
                     logger.debug(
                         "Compare mode: commit %s ('%s') excluded, matched PR commit SHA via association fallback.",
                         commit.sha,
@@ -226,16 +205,15 @@ class DataMiner:
                     del commits_without_pr[commit]
 
         for commit in commits_without_pr:
-            subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+            subject = self._get_commit_subject(commit)
             logger.debug("Compare mode: commit %s ('%s') classified as direct commit.", commit.sha, subject)
 
         data.pull_requests = pulls
         sorted_pr_commit_shas = sorted(pr_commit_shas)
         logger.debug(
-            "Compare mode: total %d unique PR-associated commit SHA(s) (showing up to %d): %s",
+            "Compare mode: total %d unique PR-associated commit SHA(s): %s",
             len(sorted_pr_commit_shas),
-            _MAX_LOGGED_PR_COMMIT_SHAS,
-            sorted_pr_commit_shas[:_MAX_LOGGED_PR_COMMIT_SHAS],
+            sorted_pr_commit_shas,
         )
 
         data.commits = commits_without_pr
@@ -253,17 +231,16 @@ class DataMiner:
         home_repository: Repository,
     ) -> None:
         """
-        Store `pr` alongside its home repository and add all commit SHAs GitHub associates with it
-        (via `get_commits()` plus `merge_commit_sha`) to `pr_commit_shas`.
+        Store `pr` alongside its home repository and add all commit SHAs GitHub associates with it.
 
-        dev note: `pull.get_commits()` returns all commits GitHub associates with the PR, including
-        sync-merge commits (base branch merged back into the PR branch) whose messages don't match
-        `_PR_NUMBER_RE`. Excluding them by SHA (rather than by message pattern) prevents them being
-        misclassified as stand-alone "direct commits". `merge_commit_sha` is added separately: for a
-        rebase-merge, `get_commits()` still reports the pre-rebase SHAs, not the new SHA(s) landed on
-        the base branch.
+        Notes:
+            - Uses `get_commits()` plus `merge_commit_sha` to cover both regular and rebase-merge SHAs.
+            - Sync-merge commits (base branch merged back into PR branch) are captured by SHA,
+              preventing misclassification as "direct commits".
+            - For rebase-merge, `get_commits()` returns pre-rebase SHAs; `merge_commit_sha` has the
+              new SHA(s) that landed on the base branch.
+            - In compare mode, all PRs come from home_repository; cross-repo handled elsewhere.
         """
-        # In compare mode, all PRs come from home_repository; cross-repo is handled elsewhere.
         pulls[pr] = home_repository
         pr_commits = self._safe_call(lambda p=pr: list(p.get_commits()))()
         pr_commit_sha_list = [c.sha for c in pr_commits] if pr_commits is not None else []
@@ -271,11 +248,10 @@ class DataMiner:
         if pr.merge_commit_sha:
             pr_commit_shas.add(pr.merge_commit_sha)
         logger.debug(
-            "Compare mode: PR #%d has %d commit(s) via get_commits() (showing up to %d) %s, merge_commit_sha=%s.",
+            "Compare mode: PR #%d has %d commit(s) via get_commits(): %s, merge_commit_sha=%s.",
             pr.number,
             len(pr_commit_sha_list),
-            _MAX_LOGGED_PR_COMMIT_SHAS,
-            pr_commit_sha_list[:_MAX_LOGGED_PR_COMMIT_SHAS],
+            pr_commit_sha_list,
             pr.merge_commit_sha,
         )
 
@@ -703,11 +679,16 @@ class DataMiner:
         """
         pr_numbers: set[int] = set()
         for commit in commits:
-            subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+            subject = DataMiner._get_commit_subject(commit)
             for match in _PR_NUMBER_RE.finditer(subject):
                 number_str = match.group(1) or match.group(2) or match.group(3)
                 pr_numbers.add(int(number_str))
         return pr_numbers
+
+    @staticmethod
+    def _get_commit_subject(commit: GithubCommit) -> str:
+        """Extract the first line (subject) of a commit message, or empty string if message is None."""
+        return commit.commit.message.splitlines()[0] if commit.commit.message else ""
 
     @staticmethod
     def __filter_duplicated_issues(data: MinedData) -> "MinedData":

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -26,7 +26,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed, CancelledError
 from typing import Optional, Callable
 
 import semver
-from github import Github, GithubException
+from github import Github, GithubException, UnknownObjectException
 from github.GitRelease import GitRelease
 from github.Issue import Issue
 from github.PullRequest import PullRequest
@@ -167,7 +167,7 @@ class DataMiner:
         pulls: dict[PullRequest, Repository] = {}
         pr_commit_shas: set[str] = set()
         for number in sorted(pr_numbers):
-            pr = self._safe_call(repo.get_pull)(number)
+            pr = self._safe_call(lambda n=number: self._get_pull_ignoring_not_found(repo, n))()
             if pr is None:
                 logger.debug("Compare mode: PR #%d could not be fetched; skipping.", number)
                 continue
@@ -278,6 +278,18 @@ class DataMiner:
             pr_commit_sha_list[:_MAX_LOGGED_PR_COMMIT_SHAS],
             pr.merge_commit_sha,
         )
+
+    @staticmethod
+    def _get_pull_ignoring_not_found(repo: Repository, number: int) -> Optional[PullRequest]:
+        """
+        Fetch a PR by number, treating "not found" as an expected outcome (bare `#N` commit
+        references are as likely to point at an issue as at a PR) rather than an error worth a
+        full traceback in the logs.
+        """
+        try:
+            return repo.get_pull(number)
+        except UnknownObjectException:
+            return None
 
     def _validate_tag_exists(self, repo: Repository, tag: str) -> None:
         try:

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -43,12 +43,21 @@ from release_notes_generator.utils.decorators import safe_call_decorator
 from release_notes_generator.utils.github_rate_limiter import GithubRateLimiter
 from release_notes_generator.utils.record_utils import get_id, parse_issue_id
 
+# dev note: these are GitHub-generated merge artifacts, so a match is a reliable signal that a commit
+#   is a PR merge/squash commit even if the PR itself couldn't be fetched (e.g. transient API error).
+_PR_MERGE_ARTIFACT_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)")
 # dev note: 3rd alternative catches commits whose subject leads with a bare "#N" reference
 #   (e.g. "#1403 Fix thing"), a message style left as-is by some merge strategies (e.g. rebase-merge)
 #   that don't append GitHub's "(#N)"/"Merge pull request #N" boilerplate. Without it, such PRs are
 #   never looked up at all, so their commits can't be excluded as duplicates of the PR.
+#   Unlike _PR_MERGE_ARTIFACT_RE, this is only a candidate to try fetching - #N is a common commit
+#   convention for referencing an issue and is not proof the commit belongs to a real merged PR, so it
+#   must not by itself exclude a commit (see the SHA-based check in _handle_compare_mode).
 _PR_NUMBER_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)|^#(\d+)\b")
 _COMPARE_COMMITS_MAX_RESULTS = 10_000
+# dev note: cap on how many PR-associated commit SHAs are logged at debug level, to keep verbose logs
+#   readable for large comparisons.
+_MAX_LOGGED_PR_COMMIT_SHAS = 50
 # dev note: cap on the per-commit "commit -> associated PRs" fallback lookup (see _handle_compare_mode)
 #   so a large batch of genuine direct commits can't trigger thousands of extra API calls.
 _MAX_DIRECT_COMMIT_PR_LOOKUPS = 200
@@ -172,7 +181,7 @@ class DataMiner:
             if commit.sha in pr_commit_shas:
                 logger.debug("Compare mode: commit %s ('%s') excluded, matched PR commit SHA.", commit.sha, subject)
                 continue
-            has_pr_ref = bool(_PR_NUMBER_RE.search(subject))
+            has_pr_ref = bool(_PR_MERGE_ARTIFACT_RE.search(subject))
             if has_pr_ref:
                 logger.debug("Compare mode: commit %s ('%s') excluded, subject references a PR.", commit.sha, subject)
                 continue
@@ -215,8 +224,12 @@ class DataMiner:
             logger.debug("Compare mode: commit %s ('%s') classified as direct commit.", commit.sha, subject)
 
         data.pull_requests = pulls
+        sorted_pr_commit_shas = sorted(pr_commit_shas)
         logger.debug(
-            "Compare mode: total %d unique PR-associated commit SHA(s): %s", len(pr_commit_shas), list(pr_commit_shas)
+            "Compare mode: total %d unique PR-associated commit SHA(s) (showing up to %d): %s",
+            len(sorted_pr_commit_shas),
+            _MAX_LOGGED_PR_COMMIT_SHAS,
+            sorted_pr_commit_shas[:_MAX_LOGGED_PR_COMMIT_SHAS],
         )
 
         data.commits = commits_without_pr

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -43,8 +43,15 @@ from release_notes_generator.utils.decorators import safe_call_decorator
 from release_notes_generator.utils.github_rate_limiter import GithubRateLimiter
 from release_notes_generator.utils.record_utils import get_id, parse_issue_id
 
-_PR_NUMBER_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)")
+# dev note: 3rd alternative catches commits whose subject leads with a bare "#N" reference
+#   (e.g. "#1403 Fix thing"), a message style left as-is by some merge strategies (e.g. rebase-merge)
+#   that don't append GitHub's "(#N)"/"Merge pull request #N" boilerplate. Without it, such PRs are
+#   never looked up at all, so their commits can't be excluded as duplicates of the PR.
+_PR_NUMBER_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)|^#(\d+)\b")
 _COMPARE_COMMITS_MAX_RESULTS = 10_000
+# dev note: cap on the per-commit "commit -> associated PRs" fallback lookup (see _handle_compare_mode)
+#   so a large batch of genuine direct commits can't trigger thousands of extra API calls.
+_MAX_DIRECT_COMMIT_PR_LOOKUPS = 200
 
 logger = logging.getLogger(__name__)
 
@@ -147,43 +154,108 @@ class DataMiner:
         data.compare_commit_shas = {c.sha for c in compare_commits}
         data.commits = {c: data.home_repository for c in compare_commits}
         pr_numbers = self._extract_pr_numbers_from_commits(compare_commits)
+        logger.debug("Compare mode: PR number(s) extracted from commit subjects: %s", sorted(pr_numbers))
         pulls: dict[PullRequest, Repository] = {}
         pr_commit_shas: set[str] = set()
         for number in sorted(pr_numbers):
             pr = self._safe_call(repo.get_pull)(number)
-            if pr is not None:
-                # Store each PR with its source repository for downstream filtering and processing.
-                # In compare mode, all PRs come from home_repository; cross-repo is handled elsewhere.
-                pulls[pr] = data.home_repository
-                # dev note: pull.get_commits() returns all commits GitHub associates with the PR,
-                #   including sync-merge commits (base branch merged back into the PR branch) whose
-                #   messages don't match _PR_NUMBER_RE. Excluding them by SHA (rather than by message
-                #   pattern) prevents them being misclassified as stand-alone "direct commits".
-                #   merge_commit_sha is added separately: for a rebase-merge, get_commits() still
-                #   reports the pre-rebase SHAs, not the new SHA(s) landed on the base branch.
-                pr_commits = self._safe_call(lambda p=pr: list(p.get_commits()))()
-                if pr_commits is not None:
-                    pr_commit_shas.update(c.sha for c in pr_commits)
-                if pr.merge_commit_sha:
-                    pr_commit_shas.add(pr.merge_commit_sha)
-        data.pull_requests = pulls
+            if pr is None:
+                logger.debug("Compare mode: PR #%d could not be fetched; skipping.", number)
+                continue
+            self._register_pr_commit_shas(pr, pulls, pr_commit_shas, data.home_repository)
 
         # Only include commits that aren't already accounted for by a PR
         # (commits identified by PR, or belonging to a PR's commit list, are redundant with the PR itself)
         commits_without_pr: dict[GithubCommit, Repository] = {}
         for commit in compare_commits:
-            if commit.sha in pr_commit_shas:
-                continue
             subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+            if commit.sha in pr_commit_shas:
+                logger.debug("Compare mode: commit %s ('%s') excluded, matched PR commit SHA.", commit.sha, subject)
+                continue
             has_pr_ref = bool(_PR_NUMBER_RE.search(subject))
-            if not has_pr_ref:
-                commits_without_pr[commit] = data.home_repository
+            if has_pr_ref:
+                logger.debug("Compare mode: commit %s ('%s') excluded, subject references a PR.", commit.sha, subject)
+                continue
+            commits_without_pr[commit] = data.home_repository
+
+        # dev note: some merged PR's commits never reference the PR number in any commit message at all
+        #   (e.g. "Set project version to 1.8.0") so they can't be found via _extract_pr_numbers_from_commits.
+        #   As a last-resort fallback, ask GitHub directly which merged PR(s) contain each remaining
+        #   candidate "direct commit" via the commit -> PRs association endpoint.
+        if len(commits_without_pr) > _MAX_DIRECT_COMMIT_PR_LOOKUPS:
+            logger.debug(
+                "Compare mode: %d commit(s) without a detected PR exceed the fallback lookup cap of %d; "
+                "skipping commit -> PR association fallback, some may still belong to a PR.",
+                len(commits_without_pr),
+                _MAX_DIRECT_COMMIT_PR_LOOKUPS,
+            )
+        else:
+            for commit in list(commits_without_pr):
+                associated_prs = self._safe_call(lambda c=commit: list(c.get_pulls()))()
+                for pr in associated_prs or []:
+                    if not pr.merged or pr in pulls:
+                        continue
+                    logger.debug(
+                        "Compare mode: commit %s is associated with merged PR #%d not found via commit subjects.",
+                        commit.sha,
+                        pr.number,
+                    )
+                    self._register_pr_commit_shas(pr, pulls, pr_commit_shas, data.home_repository)
+                if commit.sha in pr_commit_shas:
+                    subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+                    logger.debug(
+                        "Compare mode: commit %s ('%s') excluded, matched PR commit SHA via association fallback.",
+                        commit.sha,
+                        subject,
+                    )
+                    del commits_without_pr[commit]
+
+
+        for commit in commits_without_pr:
+            subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+            logger.debug("Compare mode: commit %s ('%s') classified as direct commit.", commit.sha, subject)
+
+        data.pull_requests = pulls
+        logger.debug("Compare mode: total %d unique PR-associated commit SHA(s): %s", len(pr_commit_shas), list(pr_commit_shas))
 
         data.commits = commits_without_pr
         logger.info(
             "Compare mode: found %d commit(s) without PR, %d PR(s).",
             len(commits_without_pr),
             len(data.pull_requests),
+        )
+
+    def _register_pr_commit_shas(
+        self,
+        pr: PullRequest,
+        pulls: dict[PullRequest, Repository],
+        pr_commit_shas: set[str],
+        home_repository: Repository,
+    ) -> None:
+        """
+        Store `pr` alongside its home repository and add all commit SHAs GitHub associates with it
+        (via `get_commits()` plus `merge_commit_sha`) to `pr_commit_shas`.
+
+        dev note: `pull.get_commits()` returns all commits GitHub associates with the PR, including
+        sync-merge commits (base branch merged back into the PR branch) whose messages don't match
+        `_PR_NUMBER_RE`. Excluding them by SHA (rather than by message pattern) prevents them being
+        misclassified as stand-alone "direct commits". `merge_commit_sha` is added separately: for a
+        rebase-merge, `get_commits()` still reports the pre-rebase SHAs, not the new SHA(s) landed on
+        the base branch.
+        """
+        # In compare mode, all PRs come from home_repository; cross-repo is handled elsewhere.
+        pulls[pr] = home_repository
+        pr_commits = self._safe_call(lambda p=pr: list(p.get_commits()))()
+        pr_commit_sha_list = [c.sha for c in pr_commits] if pr_commits is not None else []
+        pr_commit_shas.update(pr_commit_sha_list)
+        if pr.merge_commit_sha:
+            pr_commit_shas.add(pr.merge_commit_sha)
+        logger.debug(
+            "Compare mode: PR #%d has %d commit(s) via get_commits() %s, merge_commit_sha=%s.",
+            pr.number,
+            len(pr_commit_sha_list),
+            pr_commit_sha_list,
+            pr.merge_commit_sha,
         )
 
     def _validate_tag_exists(self, repo: Repository, tag: str) -> None:
@@ -600,7 +672,7 @@ class DataMiner:
         for commit in commits:
             subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
             for match in _PR_NUMBER_RE.finditer(subject):
-                number_str = match.group(1) or match.group(2)
+                number_str = match.group(1) or match.group(2) or match.group(3)
                 pr_numbers.add(int(number_str))
         return pr_numbers
 

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -41,7 +41,7 @@ from release_notes_generator.model.mined_data import MinedData
 from release_notes_generator.model.record.pull_request_record import PullRequestRecord
 from release_notes_generator.utils.decorators import safe_call_decorator
 from release_notes_generator.utils.github_rate_limiter import GithubRateLimiter
-from release_notes_generator.utils.record_utils import get_id, parse_issue_id
+from release_notes_generator.utils.record_utils import get_id, parse_issue_id, get_commit_subject
 
 # GitHub PR references: merge/squash markers and bare #N from rebase-merge commits
 _PR_MERGE_ARTIFACT_RE = re.compile(r"\(#(\d+)\)|Merge pull request #(\d+)")
@@ -161,7 +161,7 @@ class DataMiner:
         # (commits identified by PR, or belonging to a PR's commit list, are redundant with the PR itself)
         commits_without_pr: dict[GithubCommit, Repository] = {}
         for commit in compare_commits:
-            subject = self._get_commit_subject(commit)
+            subject = get_commit_subject(commit)
             if commit.sha in pr_commit_shas:
                 logger.debug("Compare mode: commit %s ('%s') excluded, matched PR commit SHA.", commit.sha, subject)
                 continue
@@ -196,7 +196,7 @@ class DataMiner:
                     self._register_pr_commit_shas(pr, pulls, pr_commit_shas, data.home_repository)
                     registered_pr_numbers.add(pr.number)
                 if commit.sha in pr_commit_shas:
-                    subject = self._get_commit_subject(commit)
+                    subject = get_commit_subject(commit)
                     logger.debug(
                         "Compare mode: commit %s ('%s') excluded, matched PR commit SHA via association fallback.",
                         commit.sha,
@@ -205,7 +205,7 @@ class DataMiner:
                     del commits_without_pr[commit]
 
         for commit in commits_without_pr:
-            subject = self._get_commit_subject(commit)
+            subject = get_commit_subject(commit)
             logger.debug("Compare mode: commit %s ('%s') classified as direct commit.", commit.sha, subject)
 
         data.pull_requests = pulls
@@ -679,16 +679,11 @@ class DataMiner:
         """
         pr_numbers: set[int] = set()
         for commit in commits:
-            subject = DataMiner._get_commit_subject(commit)
+            subject = get_commit_subject(commit)
             for match in _PR_NUMBER_RE.finditer(subject):
                 number_str = match.group(1) or match.group(2) or match.group(3)
                 pr_numbers.add(int(number_str))
         return pr_numbers
-
-    @staticmethod
-    def _get_commit_subject(commit: GithubCommit) -> str:
-        """Extract the first line (subject) of a commit message, or empty string if message is None."""
-        return commit.commit.message.splitlines()[0] if commit.commit.message else ""
 
     @staticmethod
     def __filter_duplicated_issues(data: MinedData) -> "MinedData":

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -199,10 +199,15 @@ class DataMiner:
                 _MAX_DIRECT_COMMIT_PR_LOOKUPS,
             )
         else:
+            registered_pr_numbers = {p.number for p in pulls}
             for commit in list(commits_without_pr):
                 associated_prs = self._safe_call(lambda c=commit: list(c.get_pulls()))()
                 for pr in associated_prs or []:
-                    if not pr.merged or pr in pulls:
+                    # dev note: the association endpoint returns a "simple" PR representation without
+                    #   `merged`, so reading it lazily completes the object via a real API call - route
+                    #   it through _safe_call like every other GitHub-hitting call in this method.
+                    is_merged = self._safe_call(lambda p=pr: p.merged)()
+                    if not is_merged or pr.number in registered_pr_numbers:
                         continue
                     logger.debug(
                         "Compare mode: commit %s is associated with merged PR #%d not found via commit subjects.",
@@ -210,6 +215,7 @@ class DataMiner:
                         pr.number,
                     )
                     self._register_pr_commit_shas(pr, pulls, pr_commit_shas, data.home_repository)
+                    registered_pr_numbers.add(pr.number)
                 if commit.sha in pr_commit_shas:
                     subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
                     logger.debug(
@@ -265,10 +271,11 @@ class DataMiner:
         if pr.merge_commit_sha:
             pr_commit_shas.add(pr.merge_commit_sha)
         logger.debug(
-            "Compare mode: PR #%d has %d commit(s) via get_commits() %s, merge_commit_sha=%s.",
+            "Compare mode: PR #%d has %d commit(s) via get_commits() (showing up to %d) %s, merge_commit_sha=%s.",
             pr.number,
             len(pr_commit_sha_list),
-            pr_commit_sha_list,
+            _MAX_LOGGED_PR_COMMIT_SHAS,
+            pr_commit_sha_list[:_MAX_LOGGED_PR_COMMIT_SHAS],
             pr.merge_commit_sha,
         )
 

--- a/release_notes_generator/data/miner.py
+++ b/release_notes_generator/data/miner.py
@@ -210,13 +210,14 @@ class DataMiner:
                     )
                     del commits_without_pr[commit]
 
-
         for commit in commits_without_pr:
             subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
             logger.debug("Compare mode: commit %s ('%s') classified as direct commit.", commit.sha, subject)
 
         data.pull_requests = pulls
-        logger.debug("Compare mode: total %d unique PR-associated commit SHA(s): %s", len(pr_commit_shas), list(pr_commit_shas))
+        logger.debug(
+            "Compare mode: total %d unique PR-associated commit SHA(s): %s", len(pr_commit_shas), list(pr_commit_shas)
+        )
 
         data.commits = commits_without_pr
         logger.info(

--- a/release_notes_generator/record/factory/default_record_factory.py
+++ b/release_notes_generator/record/factory/default_record_factory.py
@@ -92,6 +92,8 @@ class DefaultRecordFactory(RecordFactory):
         logger.info("Registering direct commits to records...")
         for commit, repo in data.commits.items():
             if commit.sha not in self.__registered_commits:
+                subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+                logger.debug("Direct commit registered: %s ('%s')", commit.sha, subject)
                 self._records[get_id(commit, repo)] = CommitRecord(commit)
 
         # dev note: now we have all PRs and commits registered to issues or as stand-alone records
@@ -136,6 +138,13 @@ class DefaultRecordFactory(RecordFactory):
             pr_commit_shas.add(pull.merge_commit_sha)
         related_commits = [c for c in data.commits if c.sha in pr_commit_shas]
         self.__registered_commits.update(c.sha for c in related_commits)
+        logger.debug(
+            "PR #%d: %d commit SHA(s) via get_commits() + merge_commit_sha, %d matched against mined commits: %s",
+            pull.number,
+            len(pr_commit_shas),
+            len(related_commits),
+            [c.sha for c in related_commits],
+        )
 
         pr_repo = target_repository if target_repository is not None else data.home_repository
 

--- a/release_notes_generator/record/factory/default_record_factory.py
+++ b/release_notes_generator/record/factory/default_record_factory.py
@@ -44,10 +44,6 @@ from release_notes_generator.utils.record_utils import get_id, parse_issue_id
 
 logger = logging.getLogger(__name__)
 
-# dev note: cap on how many matched commit SHAs are logged at debug level, to keep verbose logs
-#   readable for PRs with many commits.
-_MAX_LOGGED_COMMIT_SHAS = 50
-
 
 class DefaultRecordFactory(RecordFactory):
     """
@@ -96,7 +92,7 @@ class DefaultRecordFactory(RecordFactory):
         logger.info("Registering direct commits to records...")
         for commit, repo in data.commits.items():
             if commit.sha not in self.__registered_commits:
-                subject = commit.commit.message.splitlines()[0] if commit.commit.message else ""
+                subject = self._miner._get_commit_subject(commit)
                 logger.debug("Direct commit registered: %s ('%s')", commit.sha, subject)
                 self._records[get_id(commit, repo)] = CommitRecord(commit)
 
@@ -144,13 +140,11 @@ class DefaultRecordFactory(RecordFactory):
         self.__registered_commits.update(c.sha for c in related_commits)
         related_commit_shas = [c.sha for c in related_commits]
         logger.debug(
-            "PR #%d: %d commit SHA(s) via get_commits() + merge_commit_sha, %d matched against mined commits "
-            "(showing up to %d): %s",
+            "PR #%d: %d commit SHA(s) via get_commits() + merge_commit_sha, %d matched against mined commits: %s",
             pull.number,
             len(pr_commit_shas),
             len(related_commits),
-            _MAX_LOGGED_COMMIT_SHAS,
-            related_commit_shas[:_MAX_LOGGED_COMMIT_SHAS],
+            related_commit_shas,
         )
 
         pr_repo = target_repository if target_repository is not None else data.home_repository

--- a/release_notes_generator/record/factory/default_record_factory.py
+++ b/release_notes_generator/record/factory/default_record_factory.py
@@ -40,7 +40,7 @@ from release_notes_generator.utils.decorators import safe_call_decorator
 from release_notes_generator.utils.github_rate_limiter import GithubRateLimiter
 
 from release_notes_generator.utils.pull_request_utils import get_issues_for_pr, extract_issue_numbers_from_body
-from release_notes_generator.utils.record_utils import get_id, parse_issue_id
+from release_notes_generator.utils.record_utils import get_id, parse_issue_id, get_commit_subject
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +92,7 @@ class DefaultRecordFactory(RecordFactory):
         logger.info("Registering direct commits to records...")
         for commit, repo in data.commits.items():
             if commit.sha not in self.__registered_commits:
-                subject = self._miner._get_commit_subject(commit)
+                subject = get_commit_subject(commit)
                 logger.debug("Direct commit registered: %s ('%s')", commit.sha, subject)
                 self._records[get_id(commit, repo)] = CommitRecord(commit)
 

--- a/release_notes_generator/record/factory/default_record_factory.py
+++ b/release_notes_generator/record/factory/default_record_factory.py
@@ -44,6 +44,10 @@ from release_notes_generator.utils.record_utils import get_id, parse_issue_id
 
 logger = logging.getLogger(__name__)
 
+# dev note: cap on how many matched commit SHAs are logged at debug level, to keep verbose logs
+#   readable for PRs with many commits.
+_MAX_LOGGED_COMMIT_SHAS = 50
+
 
 class DefaultRecordFactory(RecordFactory):
     """
@@ -138,12 +142,15 @@ class DefaultRecordFactory(RecordFactory):
             pr_commit_shas.add(pull.merge_commit_sha)
         related_commits = [c for c in data.commits if c.sha in pr_commit_shas]
         self.__registered_commits.update(c.sha for c in related_commits)
+        related_commit_shas = [c.sha for c in related_commits]
         logger.debug(
-            "PR #%d: %d commit SHA(s) via get_commits() + merge_commit_sha, %d matched against mined commits: %s",
+            "PR #%d: %d commit SHA(s) via get_commits() + merge_commit_sha, %d matched against mined commits "
+            "(showing up to %d): %s",
             pull.number,
             len(pr_commit_shas),
             len(related_commits),
-            [c.sha for c in related_commits],
+            _MAX_LOGGED_COMMIT_SHAS,
+            related_commit_shas[:_MAX_LOGGED_COMMIT_SHAS],
         )
 
         pr_repo = target_repository if target_repository is not None else data.home_repository

--- a/release_notes_generator/utils/record_utils.py
+++ b/release_notes_generator/utils/record_utils.py
@@ -228,3 +228,16 @@ def format_row_with_suppression(template: str, values: dict[str, Any]) -> str:
         result = re.sub(placeholder(key), str(value), result, flags=re.IGNORECASE)
 
     return re.sub(r"\s+", " ", result).strip()
+
+
+def get_commit_subject(commit: Commit) -> str:
+    """
+    Extract the first line (subject) of a commit message.
+
+    Parameters:
+        commit: A GitHub commit object.
+
+    Returns:
+        The first line of the commit message, or empty string if message is None.
+    """
+    return commit.commit.message.splitlines()[0] if commit.commit.message else ""

--- a/tests/unit/release_notes_generator/data/test_miner.py
+++ b/tests/unit/release_notes_generator/data/test_miner.py
@@ -816,6 +816,42 @@ def test_mine_data_compare_mode_ignores_unmerged_pr_from_association_fallback(
     assert "directsha" in {c.sha for c in data.commits}
 
 
+def test_mine_data_compare_mode_association_fallback_dedupes_by_pr_number(
+    mocker: MockerFixture, mock_repo: Repository
+) -> None:
+    """The commit -> PRs association endpoint can return a fresh PullRequest instance for a PR already
+    discovered (e.g. via another commit's association lookup), distinct by object identity from that
+    prior instance even though it's the same real PR. Dedup must be by PR number, not object identity,
+    or the same PR ends up registered twice in data.pull_requests."""
+    commit_a = mocker.Mock()
+    commit_a.sha = "shaA"
+    commit_a.commit.message = "Part of a PR but message doesn't say so (A)"
+
+    commit_b = mocker.Mock()
+    commit_b.sha = "shaB"
+    commit_b.commit.message = "Part of a PR but message doesn't say so (B)"
+
+    pr99_via_a = mocker.Mock(spec=PullRequest)
+    pr99_via_a.number = 99
+    pr99_via_a.merged = True
+    pr99_via_a.merge_commit_sha = None
+    pr99_via_a.get_commits.return_value = [commit_a, commit_b]
+    commit_a.get_pulls.return_value = [pr99_via_a]
+
+    pr99_via_b = mocker.Mock(spec=PullRequest)
+    pr99_via_b.number = 99
+    pr99_via_b.merged = True
+    pr99_via_b.merge_commit_sha = None
+    pr99_via_b.get_commits.return_value = [commit_a, commit_b]
+    commit_b.get_pulls.return_value = [pr99_via_b]
+
+    miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_a, commit_b])
+    data = miner.mine_data()
+
+    assert len(data.pull_requests) == 1
+    assert data.commits == {}
+
+
 def test_mine_data_compare_mode_skips_association_fallback_above_cap(mocker, mock_repo):
     """When too many commits lack a detected PR, the per-commit association fallback is skipped
     rather than issuing one API call per commit."""

--- a/tests/unit/release_notes_generator/data/test_miner.py
+++ b/tests/unit/release_notes_generator/data/test_miner.py
@@ -570,6 +570,19 @@ def test_extract_pr_numbers_multiline_message(mocker):
     assert DataMiner._extract_pr_numbers_from_commits([commit]) == set()
 
 
+def test_extract_pr_numbers_leading_bare_hash_format(mocker):
+    commit = mocker.Mock()
+    commit.commit.message = "#1403 Investigate and fix omd dockerfile certificate issue"
+    assert DataMiner._extract_pr_numbers_from_commits([commit]) == {1403}
+
+
+def test_extract_pr_numbers_leading_bare_hash_not_matched_mid_subject(mocker):
+    commit = mocker.Mock()
+    commit.commit.message = "Feature/#1366 prebuild kerberos dependencies"
+    assert DataMiner._extract_pr_numbers_from_commits([commit]) == set()
+
+
+
 # --- mine_data compare mode ---
 
 
@@ -698,6 +711,7 @@ def test_mine_data_compare_mode_no_pr_numbers_in_message(mocker, mock_repo):
     commit_mock = mocker.Mock()
     commit_mock.sha = "bumpsha"
     commit_mock.commit.message = "Bump version to 2.6.4"
+    commit_mock.get_pulls.return_value = []
 
     miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_mock])
     data = miner.mine_data()
@@ -734,6 +748,68 @@ def test_mine_data_compare_mode_excludes_sync_merge_commit_belonging_to_pr(
 
     assert pr7 in data.pull_requests
     assert data.commits == {}
+
+
+def test_mine_data_compare_mode_finds_pr_via_commit_association_fallback(
+    mocker: MockerFixture, mock_repo: Repository
+) -> None:
+    """A merged PR's commit message may never reference the PR number at all (e.g. "Set project
+    version to 1.8.0"). Such commits must still be excluded via the commit -> PRs association
+    fallback, not left as misclassified direct commits (issue #337 follow-up)."""
+    commit_mock = mocker.Mock()
+    commit_mock.sha = "versionbumpsha"
+    commit_mock.commit.message = "Set project version to 1.8.0"
+
+    pr1430 = mocker.Mock(spec=PullRequest)
+    pr1430.number = 1430
+    pr1430.merged = True
+    pr1430.merge_commit_sha = "mergeshaxyz"
+    pr1430.get_commits.return_value = [commit_mock]
+    commit_mock.get_pulls.return_value = [pr1430]
+
+    miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_mock])
+    data = miner.mine_data()
+
+    assert pr1430 in data.pull_requests
+    assert data.commits == {}
+
+
+def test_mine_data_compare_mode_ignores_unmerged_pr_from_association_fallback(
+    mocker: MockerFixture, mock_repo: Repository
+) -> None:
+    """An open (not-yet-merged) PR returned by the commit association endpoint must not suppress
+    a direct commit."""
+    commit_mock = mocker.Mock()
+    commit_mock.sha = "directsha"
+    commit_mock.commit.message = "Quick fix"
+
+    open_pr = mocker.Mock(spec=PullRequest)
+    open_pr.number = 55
+    open_pr.merged = False
+    commit_mock.get_pulls.return_value = [open_pr]
+
+    miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_mock])
+    data = miner.mine_data()
+
+    assert "directsha" in {c.sha for c in data.commits}
+
+
+def test_mine_data_compare_mode_skips_association_fallback_above_cap(mocker, mock_repo):
+    """When too many commits lack a detected PR, the per-commit association fallback is skipped
+    rather than issuing one API call per commit."""
+    commits = []
+    for i in range(201):
+        commit_mock = mocker.Mock()
+        commit_mock.sha = f"sha{i}"
+        commit_mock.commit.message = "Direct change"
+        commits.append(commit_mock)
+
+    miner = _make_compare_miner(mocker, mock_repo, compare_commits=commits)
+    data = miner.mine_data()
+
+    assert len(data.commits) == 201
+    for commit_mock in commits:
+        commit_mock.get_pulls.assert_not_called()
 
 
 def test_mine_data_compare_mode_warns_on_total_commits_overflow(mocker, mock_repo):

--- a/tests/unit/release_notes_generator/data/test_miner.py
+++ b/tests/unit/release_notes_generator/data/test_miner.py
@@ -20,7 +20,7 @@ import pytest
 from datetime import datetime
 from typing import Optional
 
-from github import Github, GithubException
+from github import Github, GithubException, UnknownObjectException
 from github.Commit import Commit
 from github.GitRelease import GitRelease
 from github.Issue import Issue
@@ -521,6 +521,28 @@ def test_fetch_prs_for_fetched_cross_issues(mocker, mock_repo):
     assert key_ok in result and result[key_ok] == [pr_obj]
     assert key_err in result and result[key_err] == []
     warn_mock.assert_called_once()
+
+
+# --- _get_pull_ignoring_not_found ---
+
+
+def test_get_pull_ignoring_not_found_returns_none_on_404(mocker, mock_repo):
+    """A bare `#N` commit reference is as likely to point at an issue as at a PR; a 404 for it is
+    expected and must not surface as an error-level traceback."""
+    mock_repo.get_pull.side_effect = UnknownObjectException(404, {"message": "Not Found"}, None)
+    error_mock = mocker.patch("release_notes_generator.data.miner.logger.error")
+
+    result = DataMiner._get_pull_ignoring_not_found(mock_repo, 1384)
+
+    assert result is None
+    error_mock.assert_not_called()
+
+
+def test_get_pull_ignoring_not_found_propagates_other_errors(mock_repo):
+    mock_repo.get_pull.side_effect = GithubException(403, {"message": "rate limited"}, None)
+
+    with pytest.raises(GithubException):
+        DataMiner._get_pull_ignoring_not_found(mock_repo, 1384)
 
 
 # --- _extract_pr_numbers_from_commits ---

--- a/tests/unit/release_notes_generator/data/test_miner.py
+++ b/tests/unit/release_notes_generator/data/test_miner.py
@@ -615,6 +615,7 @@ def _make_compare_miner(mocker, mock_repo, *, from_tag="v2.6.3", to_tag="v2.6.4"
     else:
         default_pr = mocker.Mock(spec=PullRequest)
         default_pr.get_commits.return_value = []
+        default_pr.merge_commit_sha = None
         mock_repo.get_pull.return_value = default_pr
 
     github_mock = mocker.Mock(spec=Github)
@@ -645,6 +646,7 @@ def test_mine_data_compare_mode_fetches_prs_by_number(mocker, mock_repo):
     pr_mock = mocker.Mock(spec=PullRequest)
     pr_mock.number = 42
     pr_mock.get_commits.return_value = []
+    pr_mock.merge_commit_sha = None
 
     miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_mock],
                                 get_pull_side_effect=lambda n: pr_mock if n == 42 else None)
@@ -663,9 +665,11 @@ def test_mine_data_compare_mode_multiple_prs(mocker, mock_repo):
     pr10 = mocker.Mock(spec=PullRequest)
     pr10.number = 10
     pr10.get_commits.return_value = []
+    pr10.merge_commit_sha = None
     pr20 = mocker.Mock(spec=PullRequest)
     pr20.number = 20
     pr20.get_commits.return_value = []
+    pr20.merge_commit_sha = None
 
     miner = _make_compare_miner(mocker, mock_repo, compare_commits=[c1, c2],
                                 get_pull_side_effect=lambda n: pr10 if n == 10 else pr20)
@@ -707,6 +711,23 @@ def test_mine_data_compare_mode_skips_none_prs(mocker, mock_repo):
     assert data.pull_requests == {}
 
 
+def test_mine_data_compare_mode_bare_hash_ref_to_unresolved_pr_stays_direct_commit(mocker, mock_repo):
+    """A bare leading "#N" is a common convention for referencing an issue, not proof the commit
+    belongs to a real merged PR. If #N can't be resolved to a merged PR, the commit must remain a
+    direct commit rather than silently vanishing from the release notes."""
+    commit_mock = mocker.Mock()
+    commit_mock.sha = "dead450"
+    commit_mock.commit.message = "#450 Fix typo in docs"
+    commit_mock.get_pulls.return_value = []
+
+    miner = _make_compare_miner(mocker, mock_repo, compare_commits=[commit_mock],
+                                get_pull_side_effect=lambda _: None)
+    data = miner.mine_data()
+
+    assert data.pull_requests == {}
+    assert "dead450" in {c.sha for c in data.commits}
+
+
 def test_mine_data_compare_mode_no_pr_numbers_in_message(mocker, mock_repo):
     commit_mock = mocker.Mock()
     commit_mock.sha = "bumpsha"
@@ -737,6 +758,7 @@ def test_mine_data_compare_mode_excludes_sync_merge_commit_belonging_to_pr(
     pr7 = mocker.Mock(spec=PullRequest)
     pr7.number = 7
     pr7.get_commits.return_value = [sync_merge_commit, squash_commit]
+    pr7.merge_commit_sha = None
 
     miner = _make_compare_miner(
         mocker,

--- a/tests/unit/release_notes_generator/record/factory/test_default_record_factory.py
+++ b/tests/unit/release_notes_generator/record/factory/test_default_record_factory.py
@@ -198,6 +198,7 @@ def test_generate_with_issues_and_pulls_and_commits(mocker, mock_repo):
     data.pull_requests = {pr1: mock_repo}
     commit3 = mocker.Mock(spec=Commit)
     commit3.sha = "ghi789"
+    commit3.commit.message = "Direct commit ghi789"
     commit3.repository = mock_repo
     data.commits = {commit1: mock_repo, commit2: mock_repo, commit3: mock_repo}
 
@@ -282,6 +283,7 @@ def test_generate_with_issues_and_pulls_and_commits_with_skip_labels(mocker, moc
 
     commit3 = mocker.Mock(spec=Commit)
     commit3.sha = "ghi789"
+    commit3.commit.message = "Direct commit ghi789"
     commit3.repository.full_name = "org/repo"
 
     data = MinedData(mock_repo)


### PR DESCRIPTION
## Problem

Retesting the fix from #337 against `absa-group/ursa-metalake` (`v1.7.1`...`v1.8.1`, compare mode)
showed commits still leaking into the release notes as stand-alone "direct commits" even though
they belonged to a merged PR. Two distinct gaps were found:

1. **`_PR_NUMBER_RE` was too narrow.** It only matched `(#N)` (squash-merge style) and
   `Merge pull request #N` (merge-commit style). Commit subjects like
   `#1403 Investigate and fix omd dockerfile certificate issue` (a bare leading `#N`, no parens,
   as left behind by e.g. rebase-merge) were never recognized, so `_extract_pr_numbers_from_commits`
   never found PR #1403 in the first place — the PR was never even fetched via `get_pull()`, so its
   commit could never be excluded.

2. **A PR's commits can reference a completely different number than the PR itself.** Commit
   `d1c99fe` ("Hotfix v1.8.0 -> 1.8.1") belongs to PR #1430, but none of PR #1430's commits mention
   `#1430` anywhere — they reference unrelated numbers instead (e.g. `#1427`). No regex on commit
   text can ever discover such a PR, because the PR number literally doesn't appear in any of its
   commit messages.

## Fix

- `release_notes_generator/data/miner.py`:
  - Extended `_PR_NUMBER_RE` with a third alternative for a bare leading `#N` reference
    (`^#(\d+)\b`), so PRs like #1403 are looked up instead of silently skipped.
  - Added a last-resort fallback in `_handle_compare_mode`: for each commit still classified as a
    "direct commit" candidate after the message-based pass, call GitHub's
    commit → associated-PRs endpoint (`commit.get_pulls()`). If it resolves to a **merged** PR, that
    PR's full commit set (`get_commits()` + `merge_commit_sha`) is registered and the commit is
    excluded — regardless of what its message says.
  - Capped the fallback at `_MAX_DIRECT_COMMIT_PR_LOOKUPS` (200) to bound worst-case extra API calls
    for repositories/ranges with genuinely many direct commits; skips with a debug log beyond that.
  - Extracted the shared PR-commit-SHA registration logic into `_register_pr_commit_shas` to avoid
    duplicating it between the primary and fallback passes.
  - Added debug-level logging throughout compare-mode commit classification (extracted PR numbers,
    per-PR commit SHAs, exclusion/classification reason per commit) to make future retests
    diagnosable from `INPUT_VERBOSE=true` output alone.
- `release_notes_generator/record/factory/default_record_factory.py`: added a debug log line when a
  commit is registered as a direct commit, for the same diagnostic reason (since-time mode).

## Testing

- Added unit tests in `test_miner.py`:
  - leading bare `#N` PR-number extraction (positive and negative case).
  - commit → PR association fallback resolves a PR that has no textual reference to itself.
  - an open (unmerged) PR from the association endpoint does not suppress a direct commit.
  - the fallback is skipped once the direct-commit count exceeds `_MAX_DIRECT_COMMIT_PR_LOOKUPS`.
- Fixed two pre-existing `test_default_record_factory.py` fixtures whose mocked commits didn't set
  `.commit.message`, now touched by the new debug log.
- Full unit suite: 537 passed.
- Re-verified locally (compare mode) against `absa-group/ursa-metalake` `v1.7.1`...`v1.8.1`:
  direct-commit count went 8 → 3 (regex fix) → 0 (fallback fix); PR count went 5 → 8, matching the
  actual repository state.
- Since-time mode (`_handle_since_time_mode`) was not affected by this bug — it fetches all closed
  PRs unconditionally rather than relying on commit-message extraction — and was not locally
  re-tested end-to-end for this change, only covered by existing unit tests.

## Release Notes

- Fixed: PR commits whose message uses a bare `#N` prefix (no parentheses) were misclassified as
  direct commits in compare mode.
- Fixed: PR commits belonging to a PR that never references its own number in any commit message
  were misclassified as direct commits in compare mode.
- Added a commit → associated-PRs fallback lookup (capped) as a last resort for resolving such
  commits in compare mode.
- Added debug-level logging for PR/commit classification in compare mode and direct-commit
  registration, to aid future diagnosis.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pull request detection from commit references, including bare `#N` formats.
  * Better handles missing or unresolved pull requests without losing direct commit entries.
  * Associates commits with merged pull requests when direct references are unavailable.
  * Prevents duplicate pull requests and limits association lookups for improved efficiency.
* **Tests**
  * Expanded coverage for pull request errors, commit associations, merge states, deduplication, and lookup limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->